### PR TITLE
job controller: use backoff-state-queue to record backoff status for job instances.

### DIFF
--- a/controllers/tensorflow/tfjob_controller.go
+++ b/controllers/tensorflow/tfjob_controller.go
@@ -21,19 +21,11 @@ import (
 	"context"
 	"fmt"
 
-	tfv1 "github.com/alibaba/kubedl/api/tensorflow/v1"
-	"github.com/alibaba/kubedl/cmd/options"
-	"github.com/alibaba/kubedl/pkg/gang_schedule/registry"
-	"github.com/alibaba/kubedl/pkg/job_controller"
-	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
-	"github.com/alibaba/kubedl/pkg/metrics"
-	"github.com/alibaba/kubedl/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
-	k8scontroller "k8s.io/kubernetes/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -42,6 +34,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	tfv1 "github.com/alibaba/kubedl/api/tensorflow/v1"
+	"github.com/alibaba/kubedl/cmd/options"
+	"github.com/alibaba/kubedl/pkg/gang_schedule/registry"
+	"github.com/alibaba/kubedl/pkg/job_controller"
+	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
+	"github.com/alibaba/kubedl/pkg/metrics"
 )
 
 const (
@@ -62,15 +61,7 @@ func NewReconciler(mgr ctrl.Manager, config job_controller.JobControllerConfigur
 		scheme: mgr.GetScheme(),
 	}
 	r.recorder = mgr.GetEventRecorderFor(r.ControllerName())
-	// Initialize pkg job controller with components we only need.
-	r.ctrl = job_controller.JobController{
-		Controller:   r,
-		Expectations: k8scontroller.NewControllerExpectations(),
-		Config:       config,
-		WorkQueue:    &util.FakeWorkQueue{},
-		Recorder:     r.recorder,
-		Metrics:      metrics.NewJobMetrics(tfv1.Kind, r.Client),
-	}
+	r.ctrl = job_controller.NewJobController(r, config, r.recorder, metrics.NewJobMetrics(tfv1.Kind, r.Client))
 	if r.ctrl.Config.EnableGangScheduling {
 		r.ctrl.GangScheduler = registry.Get(r.ctrl.Config.GangSchedulerName)
 	}

--- a/controllers/xdl/xdljob_controller.go
+++ b/controllers/xdl/xdljob_controller.go
@@ -21,19 +21,11 @@ import (
 	"fmt"
 	"strings"
 
-	xdlv1alpha1 "github.com/alibaba/kubedl/api/xdl/v1alpha1"
-	"github.com/alibaba/kubedl/cmd/options"
-	"github.com/alibaba/kubedl/pkg/gang_schedule/registry"
-	"github.com/alibaba/kubedl/pkg/job_controller"
-	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
-	"github.com/alibaba/kubedl/pkg/metrics"
-	commonutil "github.com/alibaba/kubedl/pkg/util"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
-	k8scontroller "k8s.io/kubernetes/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -43,6 +35,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	xdlv1alpha1 "github.com/alibaba/kubedl/api/xdl/v1alpha1"
+	"github.com/alibaba/kubedl/cmd/options"
+	"github.com/alibaba/kubedl/pkg/gang_schedule/registry"
+	"github.com/alibaba/kubedl/pkg/job_controller"
+	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
+	"github.com/alibaba/kubedl/pkg/metrics"
 )
 
 const (
@@ -66,15 +65,7 @@ func NewReconciler(mgr manager.Manager, config job_controller.JobControllerConfi
 		scheme: mgr.GetScheme(),
 	}
 	r.recorder = mgr.GetEventRecorderFor(r.ControllerName())
-	// Initialize pkg job controller with components we only need.
-	r.ctrl = job_controller.JobController{
-		Controller:   r,
-		Expectations: k8scontroller.NewControllerExpectations(),
-		Config:       config,
-		WorkQueue:    &commonutil.FakeWorkQueue{},
-		Recorder:     r.recorder,
-		Metrics:      metrics.NewJobMetrics(xdlv1alpha1.Kind, r.Client),
-	}
+	r.ctrl = job_controller.NewJobController(r, config, r.recorder, metrics.NewJobMetrics(xdlv1alpha1.Kind, r.Client))
 	if r.ctrl.Config.EnableGangScheduling {
 		r.ctrl.GangScheduler = registry.Get(r.ctrl.Config.GangSchedulerName)
 	}

--- a/controllers/xgboost/xgboostjob_controller.go
+++ b/controllers/xgboost/xgboostjob_controller.go
@@ -15,20 +15,11 @@ package xgboostjob
 import (
 	"context"
 
-	"github.com/alibaba/kubedl/api/xgboost/v1alpha1"
-	"github.com/alibaba/kubedl/cmd/options"
-	"github.com/alibaba/kubedl/pkg/gang_schedule/registry"
-	"github.com/alibaba/kubedl/pkg/job_controller"
-	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
-	"github.com/alibaba/kubedl/pkg/metrics"
-	"github.com/alibaba/kubedl/pkg/util"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
-	k8scontroller "k8s.io/kubernetes/pkg/controller"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -38,6 +29,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/alibaba/kubedl/api/xgboost/v1alpha1"
+	"github.com/alibaba/kubedl/cmd/options"
+	"github.com/alibaba/kubedl/pkg/gang_schedule/registry"
+	"github.com/alibaba/kubedl/pkg/job_controller"
+	v1 "github.com/alibaba/kubedl/pkg/job_controller/api/v1"
+	"github.com/alibaba/kubedl/pkg/metrics"
 )
 
 const (
@@ -53,17 +51,7 @@ func NewReconciler(mgr manager.Manager, config job_controller.JobControllerConfi
 		scheme: mgr.GetScheme(),
 	}
 	r.recorder = mgr.GetEventRecorderFor(r.ControllerName())
-
-	// Initialize pkg job controller with components we only need.
-	r.ctrl = job_controller.JobController{
-		Controller:   r,
-		Expectations: k8scontroller.NewControllerExpectations(),
-		Config:       config,
-		WorkQueue:    &util.FakeWorkQueue{},
-		Recorder:     r.recorder,
-		Client:       r.Client,
-		Metrics:      metrics.NewJobMetrics(v1alpha1.Kind, r.Client),
-	}
+	r.ctrl = job_controller.NewJobController(r, config, r.recorder, metrics.NewJobMetrics(v1alpha1.Kind, r.Client))
 	if r.ctrl.Config.EnableGangScheduling {
 		r.ctrl.GangScheduler = registry.Get(r.ctrl.Config.GangSchedulerName)
 	}

--- a/pkg/job_controller/job_test.go
+++ b/pkg/job_controller/job_test.go
@@ -183,7 +183,7 @@ func TestCleanupJobIfTTL(T *testing.T) {
 	}
 
 	var job interface{}
-	err := mainJobController.cleanupJobIfTTL(&runPolicy, jobStatus, job)
+	_, err := mainJobController.cleanupJob(&runPolicy, jobStatus, job)
 	if assert.NoError(T, err) {
 		// job field is zeroed
 		assert.Empty(T, testJobController.Job)

--- a/pkg/util/runtime.go
+++ b/pkg/util/runtime.go
@@ -18,10 +18,8 @@ package util
 
 import (
 	"errors"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -71,38 +69,3 @@ func ToServicePointerList(list []corev1.Service) []*corev1.Service {
 	}
 	return ret
 }
-
-// FakeWorkQueue implements RateLimitingInterface but actually does nothing.
-type FakeWorkQueue struct{}
-
-var _ workqueue.Interface = &FakeWorkQueue{}
-
-// Add WorkQueue Add method
-func (f *FakeWorkQueue) Add(item interface{}) {}
-
-// Len WorkQueue Len method
-func (f *FakeWorkQueue) Len() int { return 0 }
-
-// Get WorkQueue Get method
-func (f *FakeWorkQueue) Get() (item interface{}, shutdown bool) { return nil, false }
-
-// Done WorkQueue Done method
-func (f *FakeWorkQueue) Done(item interface{}) {}
-
-// ShutDown WorkQueue ShutDown method
-func (f *FakeWorkQueue) ShutDown() {}
-
-// ShuttingDown WorkQueue ShuttingDown method
-func (f *FakeWorkQueue) ShuttingDown() bool { return true }
-
-// AddAfter WorkQueue AddAfter method
-func (f *FakeWorkQueue) AddAfter(item interface{}, duration time.Duration) {}
-
-// AddRateLimited WorkQueue AddRateLimited method
-func (f *FakeWorkQueue) AddRateLimited(item interface{}) {}
-
-// Forget WorkQueue Forget method
-func (f *FakeWorkQueue) Forget(item interface{}) {}
-
-// NumRequeues WorkQueue NumRequeues method
-func (f *FakeWorkQueue) NumRequeues(item interface{}) int { return 0 }


### PR DESCRIPTION
1. use backoff-state-queue to record backoff status for job instances.
2. refactor to reduce useless code.