### PR TITLE
crd: additional columns for richer information outputs in terminal.

### DIFF
--- a/api/pytorch/v1/types.go
+++ b/api/pytorch/v1/types.go
@@ -26,6 +26,10 @@ import (
 // +resource:path=pytorchjob
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[-1:].type`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Finished-TTL",type=integer,JSONPath=`.spec.ttlSecondsAfterFinished`
+// +kubebuilder:printcolumn:name="Max-Lifetime",type=integer,JSONPath=`.spec.activeDeadlineSeconds`
 
 // Represents a PyTorchJob resource.
 type PyTorchJob struct {

--- a/api/tensorflow/v1/types.go
+++ b/api/tensorflow/v1/types.go
@@ -25,6 +25,10 @@ import (
 // +resource:path=tfjob
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[-1:].type`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Finished-TTL",type=integer,JSONPath=`.spec.ttlSecondsAfterFinished`
+// +kubebuilder:printcolumn:name="Max-Lifetime",type=integer,JSONPath=`.spec.activeDeadlineSeconds`
 
 // TFJob represents a TFJob resource.
 type TFJob struct {

--- a/api/xdl/v1alpha1/types.go
+++ b/api/xdl/v1alpha1/types.go
@@ -55,6 +55,10 @@ type XDLJobSpec struct {
 // +resource:path=xdljob
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[-1:].type`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Finished-TTL",type=integer,JSONPath=`.spec.ttlSecondsAfterFinished`
+// +kubebuilder:printcolumn:name="Max-Lifetime",type=integer,JSONPath=`.spec.activeDeadlineSeconds`
 
 // XDLJob is the Schema for the xdljobs API
 // +k8s:openapi-gen=true

--- a/api/xgboost/v1alpha1/types.go
+++ b/api/xgboost/v1alpha1/types.go
@@ -50,6 +50,10 @@ type XGBoostJobStatus struct {
 // +resource:path=xgboostjob
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced
+// +kubebuilder:printcolumn:name="State",type=string,JSONPath=`.status.conditions[-1:].type`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
+// +kubebuilder:printcolumn:name="Finished-TTL",type=integer,JSONPath=`.spec.ttlSecondsAfterFinished`
+// +kubebuilder:printcolumn:name="Max-Lifetime",type=integer,JSONPath=`.spec.activeDeadlineSeconds`
 
 // XGBoostJob is the Schema for the xgboostjobs API
 // +k8s:openapi-gen=true

--- a/config/crd/bases/kubeflow.org_pytorchjobs.yaml
+++ b/config/crd/bases/kubeflow.org_pytorchjobs.yaml
@@ -8,6 +8,19 @@ metadata:
   creationTimestamp: null
   name: pytorchjobs.kubeflow.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .spec.ttlSecondsAfterFinished
+    name: Finished-TTL
+    type: integer
+  - JSONPath: .spec.activeDeadlineSeconds
+    name: Max-Lifetime
+    type: integer
   group: kubeflow.org
   names:
     kind: PyTorchJob

--- a/config/crd/bases/kubeflow.org_tfjobs.yaml
+++ b/config/crd/bases/kubeflow.org_tfjobs.yaml
@@ -8,6 +8,19 @@ metadata:
   creationTimestamp: null
   name: tfjobs.kubeflow.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .spec.ttlSecondsAfterFinished
+    name: Finished-TTL
+    type: integer
+  - JSONPath: .spec.activeDeadlineSeconds
+    name: Max-Lifetime
+    type: integer
   group: kubeflow.org
   names:
     kind: TFJob

--- a/config/crd/bases/xdl.kubedl.io_xdljobs.yaml
+++ b/config/crd/bases/xdl.kubedl.io_xdljobs.yaml
@@ -8,6 +8,19 @@ metadata:
   creationTimestamp: null
   name: xdljobs.xdl.kubedl.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .spec.ttlSecondsAfterFinished
+    name: Finished-TTL
+    type: integer
+  - JSONPath: .spec.activeDeadlineSeconds
+    name: Max-Lifetime
+    type: integer
   group: xdl.kubedl.io
   names:
     kind: XDLJob

--- a/config/crd/bases/xgboostjob.kubeflow.org_xgboostjobs.yaml
+++ b/config/crd/bases/xgboostjob.kubeflow.org_xgboostjobs.yaml
@@ -8,6 +8,19 @@ metadata:
   creationTimestamp: null
   name: xgboostjobs.xgboostjob.kubeflow.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.conditions[-1:].type
+    name: State
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
+  - JSONPath: .spec.ttlSecondsAfterFinished
+    name: Finished-TTL
+    type: integer
+  - JSONPath: .spec.activeDeadlineSeconds
+    name: Max-Lifetime
+    type: integer
   group: xgboostjob.kubeflow.org
   names:
     kind: XGBoostJob
@@ -123,6 +136,7 @@ spec:
             replicaStatuses:
               description: ReplicaStatuses is map of ReplicaType and ReplicaStatus,
                 specifies the status of each replica.
+              type: object
             startTime:
               description: Represents time when the job was acknowledged by the job
                 controller. It is not guaranteed to be set in happens-before order


### PR DESCRIPTION
e.g:

> $ kubectl get tfjobs -n kubedl
NAME    STATE     AGE   TTL-SECONDS   ACTIVE-SECONDS
mnist     Created   16d     100                       99999