### PR TITLE
fixes and optimizations in single patch

### DIFF
--- a/api/pytorch/v1/constants.go
+++ b/api/pytorch/v1/constants.go
@@ -29,6 +29,8 @@ const (
 	DefaultContainerName = "pytorch"
 	// DefaultPort is default value of the port.
 	DefaultPort = 23456
-	// DefaultRestartPolicy is default RestartPolicy for PyTorchReplicaSpec.
-	DefaultRestartPolicy = common.RestartPolicyOnFailure
+	// DefaultMasterRestartPolicy is default RestartPolicy for Master PyTorchReplicaSpec.
+	DefaultMasterRestartPolicy = common.RestartPolicyExitCode
+	// DefaultWorkerRestartPolicy is default RestartPolicy for Worker PyTorchReplicaSpec,
+	DefaultWorkerRestartPolicy = common.RestartPolicyOnFailure
 )

--- a/api/pytorch/v1/defaults.go
+++ b/api/pytorch/v1/defaults.go
@@ -56,13 +56,21 @@ func setDefaultPort(spec *v1.PodSpec) {
 		})
 	}
 }
-
-func setDefaultReplicas(spec *common.ReplicaSpec) {
+func setDefaultMasterReplicas(spec *common.ReplicaSpec) {
 	if spec.Replicas == nil {
 		spec.Replicas = Int32(1)
 	}
 	if spec.RestartPolicy == "" {
-		spec.RestartPolicy = DefaultRestartPolicy
+		spec.RestartPolicy = DefaultMasterRestartPolicy
+	}
+}
+
+func setDefaultWorkerReplicas(spec *common.ReplicaSpec) {
+	if spec.Replicas == nil {
+		spec.Replicas = Int32(1)
+	}
+	if spec.RestartPolicy == "" {
+		spec.RestartPolicy = DefaultWorkerRestartPolicy
 	}
 }
 
@@ -96,9 +104,12 @@ func SetDefaults_PyTorchJob(job *PyTorchJob) {
 	setTypeNamesToCamelCase(job)
 
 	for rType, spec := range job.Spec.PyTorchReplicaSpecs {
-		// Set default replicas to 1.
-		setDefaultReplicas(spec)
+		// Set default replicas and restart policy.
+		if rType == PyTorchReplicaTypeWorker {
+			setDefaultWorkerReplicas(spec)
+		}
 		if rType == PyTorchReplicaTypeMaster {
+			setDefaultMasterReplicas(spec)
 			// Set default port to pytorch container of Master.
 			setDefaultPort(&spec.Template.Spec)
 		}

--- a/api/tensorflow/v1/constants.go
+++ b/api/tensorflow/v1/constants.go
@@ -30,5 +30,5 @@ const (
 	// DefaultPort is default value of the port.
 	DefaultPort = 2222
 	// DefaultRestartPolicy is default RestartPolicy for TFReplicaSpec.
-	DefaultRestartPolicy = common.RestartPolicyNever
+	DefaultRestartPolicy = common.RestartPolicyExitCode
 )

--- a/controllers/pytorch/pytorchjob_controller.go
+++ b/controllers/pytorch/pytorchjob_controller.go
@@ -193,7 +193,7 @@ func (r *PytorchJobReconciler) SetClusterSpec(job interface{}, podTemplate *core
 	}
 
 	masterAddr := job_controller.GenGeneralName(pytorchJob.Name, strings.ToLower(string(pytorchv1.PyTorchReplicaTypeMaster)), strconv.Itoa(0))
-	if v1.ReplicaType(rtype) == pytorchv1.PyTorchReplicaTypeMaster {
+	if rtype == strings.ToLower(string(pytorchv1.PyTorchReplicaTypeMaster)) {
 		if rank != 0 {
 			return fmt.Errorf("invalid config: There should be only a single master with index=0")
 		}


### PR DESCRIPTION
1. bugfix: string cases mismatch when compare replica types.
2. optimization: reset pytorch replicas default restart policy, set Master to OnExitCode, set Worker to OnFailure.
3. fix: generate a new expectation when create new pod conflicts, so that controller will trigger a new reconciliation and reach a expected state finally.