### PR TITLE
fix: resolve errors when running Makefile and revise manifests files.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 IMG ?= kubedl/kubedl:v0.1.0
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd"
+CRD_OPTIONS ?= "crd:trivialVersions=true,maxDescLen=0"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/elasticdl.org_elasticdljobs.yaml
+++ b/config/crd/bases/elasticdl.org_elasticdljobs.yaml
@@ -32,82 +32,57 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: ElasticDLJob Represents an elasticdl Job instance
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
-            description: Standard Kubernetes object's metadata.
             type: object
           spec:
-            description: Specification of the desired state of the ElasticDLJob.
             properties:
               activeDeadlineSeconds:
-                description: Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
                 format: int64
                 type: integer
               backoffLimit:
-                description: Optional number of retries before marking this job failed.
                 format: int32
                 type: integer
               cleanPodPolicy:
-                description: CleanPodPolicy defines the policy to kill pods after the job completes. Default to Running.
                 type: string
               elasticdlReplicaSpecs:
                 additionalProperties:
-                  description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job. One of Always, OnFailure, Never and ExitCode. Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that will be created for this replica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
-                              description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -117,18 +92,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -139,7 +109,6 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -148,26 +117,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -177,18 +138,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -204,32 +160,22 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -241,22 +187,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -265,26 +207,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -296,16 +230,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -313,32 +244,22 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -350,22 +271,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -374,26 +291,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -405,16 +314,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -423,94 +329,69 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -521,72 +402,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -594,64 +454,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -659,31 +504,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -691,37 +530,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -729,77 +558,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -810,37 +621,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -848,54 +649,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -904,7 +694,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -913,113 +702,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1027,77 +783,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1105,27 +842,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1133,130 +862,97 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
                                         type: string
                                       value:
                                         type: string
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1267,72 +963,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1340,64 +1015,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1405,31 +1065,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1437,37 +1091,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1475,114 +1119,86 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1590,54 +1206,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1646,7 +1251,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1655,113 +1259,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1769,80 +1340,60 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1850,27 +1401,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1878,135 +1421,99 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                                 properties:
                                   hostnames:
-                                    description: Hostnames for the above IP address.
                                     items:
                                       type: string
                                     type: array
                                   ip:
-                                    description: IP address of the host file entry.
                                     type: string
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2017,72 +1524,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2090,64 +1576,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2155,31 +1626,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2187,37 +1652,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2225,77 +1680,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2306,37 +1743,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2344,54 +1771,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2400,7 +1816,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2409,113 +1824,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2523,77 +1905,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2601,27 +1964,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2629,19 +1984,16 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -2650,92 +2002,66 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
                                     properties:
                                       name:
-                                        description: Name of a property to set
                                         type: string
                                       value:
-                                        description: Value of a property to set
                                         type: string
                                     required:
                                     - name
@@ -2743,79 +2069,55 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
-                              description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2827,18 +2129,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -2851,143 +2149,104 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
-                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains Azure Storage Account Name and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -2995,85 +2254,63 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: Items is a list of downward API volume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
@@ -3084,184 +2321,136 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -3269,92 +2458,67 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
                                         items:
-                                          description: Projection that may be projected along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3362,54 +2526,40 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its keys must be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI data to project
                                               properties:
                                                 items:
-                                                  description: Items is a list of DownwardAPIVolume file
                                                   items:
-                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                     properties:
                                                       fieldRef:
-                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                         properties:
                                                           apiVersion:
-                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                             type: string
                                                           fieldPath:
-                                                            description: Path of the field to select in the specified API version.
                                                             type: string
                                                         required:
                                                         - fieldPath
                                                         type: object
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                                         properties:
                                                           containerName:
-                                                            description: 'Container name: required for volumes, optional for env vars'
                                                             type: string
                                                           divisor:
                                                             anyOf:
                                                             - type: integer
                                                             - type: string
-                                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                             x-kubernetes-int-or-string: true
                                                           resource:
-                                                            description: 'Required: resource to select'
                                                             type: string
                                                         required:
                                                         - resource
@@ -3420,22 +2570,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3443,24 +2587,18 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative to the mount point of the file to project the token into.
                                                   type: string
                                               required:
                                               - path
@@ -3471,103 +2609,74 @@ spec:
                                     - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references an already created Quobyte volume by name.
                                         type: string
                                     required:
                                     - registry
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection Domain for the configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication with Gateway, default false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -3575,26 +2684,19 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3602,49 +2704,35 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -3658,53 +2746,40 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'A map of ElasticDLReplicaType (type) to ReplicaSpec (value). Specifies the ElasticDL cluster configuration. For example,   {     "Master": ElasticDLReplicaSpec,   }'
                 type: object
               schedulingPolicy:
-                description: SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling
                 properties:
                   minAvailable:
                     format: int32
                     type: integer
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.
                 format: int32
                 type: integer
             required:
             - elasticdlReplicaSpecs
             type: object
           status:
-            description: Most recently observed status of the ElasticDLJob. Read-only (modified by the system).
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               conditions:
-                description: Conditions is an array of current observed job conditions.
                 items:
-                  description: JobCondition describes the state of the job at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of job condition.
                       type: string
                   required:
                   - status
@@ -3712,34 +2787,26 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
                 additionalProperties:
-                  description: ReplicaStatus represents the current observed state of the replica.
                   properties:
                     active:
-                      description: The number of actively running pods.
                       format: int32
                       type: integer
                     evicted:
-                      description: The number of pods which reached phase Failed and reason is Evicted, it is included in the number of Failed.
                       format: int32
                       type: integer
                     failed:
-                      description: The number of pods which reached phase Failed.
                       format: int32
                       type: integer
                     succeeded:
-                      description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             required:

--- a/config/crd/bases/kubedl.io_marsjobs.yaml
+++ b/config/crd/bases/kubedl.io_marsjobs.yaml
@@ -32,81 +32,57 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: MarsJob represents a mars job instance nad
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: MarsJobSpec defines the desired state of MarsJob
             properties:
               activeDeadlineSeconds:
-                description: Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
                 format: int64
                 type: integer
               backoffLimit:
-                description: Optional number of retries before marking this job failed.
                 format: int32
                 type: integer
               cleanPodPolicy:
-                description: CleanPodPolicy defines the policy to kill pods after the job completes. Default to Running.
                 type: string
               marsReplicaSpecs:
                 additionalProperties:
-                  description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job. One of Always, OnFailure, Never and ExitCode. Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that will be created for this replica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
-                              description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -116,18 +92,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -138,7 +109,6 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -147,26 +117,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -176,18 +138,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -203,32 +160,22 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -240,22 +187,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -264,26 +207,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -295,16 +230,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -312,32 +244,22 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -349,22 +271,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -373,26 +291,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -404,16 +314,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -422,94 +329,69 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -520,72 +402,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -593,64 +454,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -658,31 +504,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -690,37 +530,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -728,77 +558,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -809,37 +621,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -847,54 +649,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -903,7 +694,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -912,113 +702,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1026,77 +783,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1104,27 +842,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1132,130 +862,97 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
                                         type: string
                                       value:
                                         type: string
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1266,72 +963,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1339,64 +1015,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1404,31 +1065,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1436,37 +1091,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1474,114 +1119,86 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1589,54 +1206,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1645,7 +1251,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1654,113 +1259,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1768,80 +1340,60 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1849,27 +1401,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1877,135 +1421,99 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                                 properties:
                                   hostnames:
-                                    description: Hostnames for the above IP address.
                                     items:
                                       type: string
                                     type: array
                                   ip:
-                                    description: IP address of the host file entry.
                                     type: string
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2016,72 +1524,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2089,64 +1576,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2154,31 +1626,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2186,37 +1652,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2224,77 +1680,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2305,37 +1743,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2343,54 +1771,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2399,7 +1816,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2408,113 +1824,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2522,77 +1905,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2600,27 +1964,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2628,19 +1984,16 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -2649,92 +2002,66 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
                                     properties:
                                       name:
-                                        description: Name of a property to set
                                         type: string
                                       value:
-                                        description: Value of a property to set
                                         type: string
                                     required:
                                     - name
@@ -2742,79 +2069,55 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
-                              description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2826,18 +2129,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -2850,143 +2149,104 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
-                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains Azure Storage Account Name and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -2994,85 +2254,63 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: Items is a list of downward API volume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
@@ -3083,184 +2321,136 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -3268,92 +2458,67 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
                                         items:
-                                          description: Projection that may be projected along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3361,54 +2526,40 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its keys must be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI data to project
                                               properties:
                                                 items:
-                                                  description: Items is a list of DownwardAPIVolume file
                                                   items:
-                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                     properties:
                                                       fieldRef:
-                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                         properties:
                                                           apiVersion:
-                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                             type: string
                                                           fieldPath:
-                                                            description: Path of the field to select in the specified API version.
                                                             type: string
                                                         required:
                                                         - fieldPath
                                                         type: object
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                                         properties:
                                                           containerName:
-                                                            description: 'Container name: required for volumes, optional for env vars'
                                                             type: string
                                                           divisor:
                                                             anyOf:
                                                             - type: integer
                                                             - type: string
-                                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                             x-kubernetes-int-or-string: true
                                                           resource:
-                                                            description: 'Required: resource to select'
                                                             type: string
                                                         required:
                                                         - resource
@@ -3419,22 +2570,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3442,24 +2587,18 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative to the mount point of the file to project the token into.
                                                   type: string
                                               required:
                                               - path
@@ -3470,103 +2609,74 @@ spec:
                                     - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references an already created Quobyte volume by name.
                                         type: string
                                     required:
                                     - registry
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection Domain for the configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication with Gateway, default false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -3574,26 +2684,19 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3601,49 +2704,35 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -3657,45 +2746,35 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: MarsReplicaSpecs is a map of MarsReplicaType(key) to ReplicaSpec(value), specifying replicas and template of each type.
                 type: object
               schedulingPolicy:
-                description: SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling
                 properties:
                   minAvailable:
                     format: int32
                     type: integer
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.
                 format: int32
                 type: integer
               webHost:
-                description: WebHost is the domain address of webservice that expose to external users.
                 type: string
               workerMemoryTuningPolicy:
-                description: WorkerMemoryTuningPolicy provides multiple memory tuning policies to mars worker spec, such as cache size, cold data paths...
                 properties:
                   lockFreeFileIO:
-                    description: LockFreeFileIO indicates whether spill dirs are dedicated or not.
                     type: boolean
                   plasmaStore:
-                    description: PlasmaStore specify the socket path of plasma store that handles shared memory between all worker processes.
                     type: string
                   spillDirs:
-                    description: SpillDirs specify multiple directory paths, when size of in-memory objects is about to reach the limitation, mars workers will swap cold data out to spill dirs and persist in ephemeral-storage.
                     items:
                       type: string
                     type: array
                   workerCachePercentage:
-                    description: WorkerCachePercentage specify the percentage of total available memory size can be used as cache, it will be overridden by workerCacheSize if it is been set.
                     format: int32
                     type: integer
                   workerCacheSize:
                     anyOf:
                     - type: integer
                     - type: string
-                    description: WorkerCacheSize specify the exact cache quantity can be used.
                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                     x-kubernetes-int-or-string: true
                 type: object
@@ -3703,36 +2782,26 @@ spec:
             - marsReplicaSpecs
             type: object
           status:
-            description: MarsJobStatus defines the current observed state of MarsJob
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               conditions:
-                description: Conditions is an array of current observed job conditions.
                 items:
-                  description: JobCondition describes the state of the job at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of job condition.
                       type: string
                   required:
                   - status
@@ -3740,38 +2809,29 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
                 additionalProperties:
-                  description: ReplicaStatus represents the current observed state of the replica.
                   properties:
                     active:
-                      description: The number of actively running pods.
                       format: int32
                       type: integer
                     evicted:
-                      description: The number of pods which reached phase Failed and reason is Evicted, it is included in the number of Failed.
                       format: int32
                       type: integer
                     failed:
-                      description: The number of pods which reached phase Failed.
                       format: int32
                       type: integer
                     succeeded:
-                      description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               webServiceAddresses:
-                description: WebServiceAddresses is a list of available webservices addresses for users, its length equals with WebServices.Replicas.
                 items:
                   type: string
                 type: array

--- a/config/crd/bases/kubeflow.org_mpijobs.yaml
+++ b/config/crd/bases/kubeflow.org_mpijobs.yaml
@@ -34,94 +34,67 @@ spec:
       openAPIV3Schema:
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
             properties:
               activeDeadlineSeconds:
-                description: Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
                 format: int64
                 type: integer
               backoffLimit:
-                description: Optional number of retries before marking this job failed.
                 format: int32
                 type: integer
               cleanPodPolicy:
-                description: CleanPodPolicy defines the policy to kill pods after the job completes. Default to Running.
                 type: string
               gpus:
-                description: Deprecated. Specifies the desired number of DeprecatedGPUs the MPIJob should run on. Mutually exclusive with the `Replicas` field. Note that this is deprecated in favor of `ProcessingUnits` field.
                 format: int32
                 type: integer
               gpusPerNode:
-                description: The maximum number of GPUs available per node. Note that this will be ignored if the GPU resources are explicitly specified in the MPIJob pod spec. This is deprecated in favor of `ProcessingUnitsPerNode` field.
                 format: int32
                 type: integer
               launcherOnMaster:
-                description: Run the launcher on the master. Defaults to false.
                 type: boolean
               mainContainer:
-                description: MainContainer specifies name of the main container which executes the MPI code.
                 type: string
               mpiDistribution:
-                description: MPIDistribution specifies name of the MPI framwork which is used Defaults to "OpenMPI" Options includes "OpenMPI", "IntelMPI" and "MPICH"
                 type: string
               mpiReplicaSpecs:
                 additionalProperties:
-                  description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job. One of Always, OnFailure, Never and ExitCode. Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that will be created for this replica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
-                              description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -131,18 +104,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -153,7 +121,6 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -162,26 +129,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -191,18 +150,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -218,32 +172,22 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -255,22 +199,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -279,26 +219,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -310,16 +242,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -327,32 +256,22 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -364,22 +283,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -388,26 +303,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -419,16 +326,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -437,94 +341,69 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -535,72 +414,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -608,64 +466,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -673,31 +516,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -705,37 +542,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -743,77 +570,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -824,37 +633,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -862,54 +661,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -918,7 +706,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -927,113 +714,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1041,77 +795,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1119,27 +854,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1147,130 +874,97 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
                                         type: string
                                       value:
                                         type: string
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1281,72 +975,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1354,64 +1027,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1419,31 +1077,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1451,37 +1103,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1489,114 +1131,86 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1604,54 +1218,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1660,7 +1263,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1669,113 +1271,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1783,80 +1352,60 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1864,27 +1413,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1892,135 +1433,99 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                                 properties:
                                   hostnames:
-                                    description: Hostnames for the above IP address.
                                     items:
                                       type: string
                                     type: array
                                   ip:
-                                    description: IP address of the host file entry.
                                     type: string
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2031,72 +1536,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2104,64 +1588,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2169,31 +1638,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2201,37 +1664,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2239,77 +1692,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2320,37 +1755,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2358,54 +1783,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2414,7 +1828,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2423,113 +1836,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2537,77 +1917,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2615,27 +1976,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2643,19 +1996,16 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -2664,92 +2014,66 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
                                     properties:
                                       name:
-                                        description: Name of a property to set
                                         type: string
                                       value:
-                                        description: Value of a property to set
                                         type: string
                                     required:
                                     - name
@@ -2757,79 +2081,55 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
-                              description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2841,18 +2141,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -2865,143 +2161,104 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
-                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains Azure Storage Account Name and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3009,85 +2266,63 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: Items is a list of downward API volume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
@@ -3098,184 +2333,136 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -3283,92 +2470,67 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
                                         items:
-                                          description: Projection that may be projected along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3376,54 +2538,40 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its keys must be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI data to project
                                               properties:
                                                 items:
-                                                  description: Items is a list of DownwardAPIVolume file
                                                   items:
-                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                     properties:
                                                       fieldRef:
-                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                         properties:
                                                           apiVersion:
-                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                             type: string
                                                           fieldPath:
-                                                            description: Path of the field to select in the specified API version.
                                                             type: string
                                                         required:
                                                         - fieldPath
                                                         type: object
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                                         properties:
                                                           containerName:
-                                                            description: 'Container name: required for volumes, optional for env vars'
                                                             type: string
                                                           divisor:
                                                             anyOf:
                                                             - type: integer
                                                             - type: string
-                                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                             x-kubernetes-int-or-string: true
                                                           resource:
-                                                            description: 'Required: resource to select'
                                                             type: string
                                                         required:
                                                         - resource
@@ -3434,22 +2582,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3457,24 +2599,18 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative to the mount point of the file to project the token into.
                                                   type: string
                                               required:
                                               - path
@@ -3485,103 +2621,74 @@ spec:
                                     - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references an already created Quobyte volume by name.
                                         type: string
                                     required:
                                     - registry
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection Domain for the configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication with Gateway, default false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -3589,26 +2696,19 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3616,49 +2716,35 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -3672,100 +2758,73 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: '`MPIReplicaSpecs` contains maps from `MPIReplicaType` to `ReplicaSpec` that specify the MPI replicas to run.'
                 type: object
               processingResourceType:
-                description: The processing resource type, e.g. 'nvidia.com/gpu' or 'cpu'. Defaults to 'nvidia.com/gpu'
                 type: string
               processingUnits:
-                description: Specifies the desired number of processing units the MPIJob should run on. Mutually exclusive with the `Replicas` field.
                 format: int32
                 type: integer
               processingUnitsPerNode:
-                description: The maximum number of processing units available per node. Note that this will be ignored if the processing resources are explicitly specified in the MPIJob pod spec.
                 format: int32
                 type: integer
               replicas:
-                description: Specifies the desired number of replicas the MPIJob should run on. The `PodSpec` should specify the number of processing units. Mutually exclusive with the `GPUs` or `ProcessingUnits` fields.
                 format: int32
                 type: integer
               runPolicy:
-                description: '`RunPolicy` encapsulates various runtime policies of the distributed training job, for example how to clean up resources and how long the job can stay active.'
                 properties:
                   activeDeadlineSeconds:
-                    description: Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
                     format: int64
                     type: integer
                   backoffLimit:
-                    description: Optional number of retries before marking this job failed.
                     format: int32
                     type: integer
                   cleanPodPolicy:
-                    description: CleanPodPolicy defines the policy to kill pods after the job completes. Default to Running.
                     type: string
                   schedulingPolicy:
-                    description: SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling
                     properties:
                       minAvailable:
                         format: int32
                         type: integer
                     type: object
                   ttlSecondsAfterFinished:
-                    description: TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.
                     format: int32
                     type: integer
                 type: object
               schedulingPolicy:
-                description: SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling
                 properties:
                   minAvailable:
                     format: int32
                     type: integer
                 type: object
               slotsPerWorker:
-                description: Specifies the number of slots per worker used in hostfile. Defaults to 1.
                 format: int32
                 type: integer
               template:
-                description: Describes the pod that will be created when executing an MPIJob.
                 properties:
                   metadata:
-                    description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                     type: object
                   spec:
-                    description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                     properties:
                       activeDeadlineSeconds:
-                        description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                         format: int64
                         type: integer
                       affinity:
-                        description: If specified, the pod's scheduling constraints
                         properties:
                           nodeAffinity:
-                            description: Describes node affinity scheduling rules for the pod.
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                   properties:
                                     preference:
-                                      description: A node selector term, associated with the corresponding weight.
                                       properties:
                                         matchExpressions:
-                                          description: A list of node selector requirements by node's labels.
                                           items:
-                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                             properties:
                                               key:
-                                                description: The label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3775,18 +2834,13 @@ spec:
                                             type: object
                                           type: array
                                         matchFields:
-                                          description: A list of node selector requirements by node's fields.
                                           items:
-                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                             properties:
                                               key:
-                                                description: The label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3797,7 +2851,6 @@ spec:
                                           type: array
                                       type: object
                                     weight:
-                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -3806,26 +2859,18 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                 properties:
                                   nodeSelectorTerms:
-                                    description: Required. A list of node selector terms. The terms are ORed.
                                     items:
-                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                       properties:
                                         matchExpressions:
-                                          description: A list of node selector requirements by node's labels.
                                           items:
-                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                             properties:
                                               key:
-                                                description: The label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3835,18 +2880,13 @@ spec:
                                             type: object
                                           type: array
                                         matchFields:
-                                          description: A list of node selector requirements by node's fields.
                                           items:
-                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                             properties:
                                               key:
-                                                description: The label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                 type: string
                                               values:
-                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3862,32 +2902,22 @@ spec:
                                 type: object
                             type: object
                           podAffinity:
-                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                   properties:
                                     podAffinityTerm:
-                                      description: Required. A pod affinity term, associated with the corresponding weight.
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -3899,22 +2929,18 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -3923,26 +2949,18 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -3954,16 +2972,13 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
@@ -3971,32 +2986,22 @@ spec:
                                 type: array
                             type: object
                           podAntiAffinity:
-                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                             properties:
                               preferredDuringSchedulingIgnoredDuringExecution:
-                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                 items:
-                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                   properties:
                                     podAffinityTerm:
-                                      description: Required. A pod affinity term, associated with the corresponding weight.
                                       properties:
                                         labelSelector:
-                                          description: A label query over a set of resources, in this case pods.
                                           properties:
                                             matchExpressions:
-                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                               items:
-                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                 properties:
                                                   key:
-                                                    description: key is the label key that the selector applies to.
                                                     type: string
                                                   operator:
-                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                     type: string
                                                   values:
-                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                     items:
                                                       type: string
                                                     type: array
@@ -4008,22 +3013,18 @@ spec:
                                             matchLabels:
                                               additionalProperties:
                                                 type: string
-                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                               type: object
                                           type: object
                                         namespaces:
-                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                           items:
                                             type: string
                                           type: array
                                         topologyKey:
-                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                           type: string
                                       required:
                                       - topologyKey
                                       type: object
                                     weight:
-                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                       format: int32
                                       type: integer
                                   required:
@@ -4032,26 +3033,18 @@ spec:
                                   type: object
                                 type: array
                               requiredDuringSchedulingIgnoredDuringExecution:
-                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                 items:
-                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                   properties:
                                     labelSelector:
-                                      description: A label query over a set of resources, in this case pods.
                                       properties:
                                         matchExpressions:
-                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                           items:
-                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                             properties:
                                               key:
-                                                description: key is the label key that the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                 items:
                                                   type: string
                                                 type: array
@@ -4063,16 +3056,13 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                     namespaces:
-                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                       items:
                                         type: string
                                       type: array
                                     topologyKey:
-                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                       type: string
                                   required:
                                   - topologyKey
@@ -4081,94 +3071,69 @@ spec:
                             type: object
                         type: object
                       automountServiceAccountToken:
-                        description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                         type: boolean
                       containers:
-                        description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                         items:
-                          description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in the container. Cannot be updated.
                               items:
-                                description: EnvVar represents an environment variable present in a Container.
                                 properties:
                                   name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                     type: string
                                   valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
                                     properties:
                                       configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
                                         properties:
                                           key:
-                                            description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
                                             type: boolean
                                         required:
                                         - key
                                         type: object
                                       fieldRef:
-                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                         properties:
                                           containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
                                         type: object
                                       secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
                                         properties:
                                           key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
                                             type: boolean
                                         required:
                                         - key
@@ -4179,72 +3144,51 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                               items:
-                                description: EnvFromSource represents the source of a set of ConfigMaps
                                 properties:
                                   configMapRef:
-                                    description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap must be defined
                                         type: boolean
                                     type: object
                                   prefix:
-                                    description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
-                                    description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret must be defined
                                         type: boolean
                                     type: object
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                               type: string
                             lifecycle:
-                              description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -4252,64 +3196,49 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -4317,31 +3246,25 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -4349,37 +3272,27 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -4387,77 +3300,59 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                               items:
-                                description: ContainerPort represents a network port in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
-                                    description: What host IP to bind the external port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -4468,37 +3363,27 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -4506,54 +3391,43 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             resources:
-                              description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -4562,7 +3436,6 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -4571,113 +3444,80 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                               type: object
                             securityContext:
-                              description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                   properties:
                                     add:
-                                      description: Added capabilities
                                       items:
-                                        description: Capability represent POSIX capabilities type
                                         type: string
                                       type: array
                                     drop:
-                                      description: Removed capabilities
                                       items:
-                                        description: Capability represent POSIX capabilities type
                                         type: string
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only root filesystem. Default is false.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -4685,77 +3525,58 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                               type: boolean
                             volumeDevices:
-                              description: volumeDevices is the list of block devices to be used by the container.
                               items:
-                                description: volumeDevice describes a mapping of a raw block device within a container.
                                 properties:
                                   devicePath:
-                                    description: devicePath is the path inside of the container that the device will be mapped to.
                                     type: string
                                   name:
-                                    description: name must match the name of a persistentVolumeClaim in the pod
                                     type: string
                                 required:
                                 - devicePath
@@ -4763,27 +3584,19 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                               items:
-                                description: VolumeMount describes a mounting of a Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                     type: string
                                   name:
-                                    description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -4791,130 +3604,97 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
                       dnsConfig:
-                        description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                         properties:
                           nameservers:
-                            description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                             items:
                               type: string
                             type: array
                           options:
-                            description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                             items:
-                              description: PodDNSConfigOption defines DNS resolver options of a pod.
                               properties:
                                 name:
-                                  description: Required.
                                   type: string
                                 value:
                                   type: string
                               type: object
                             type: array
                           searches:
-                            description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                             items:
                               type: string
                             type: array
                         type: object
                       dnsPolicy:
-                        description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                         type: string
                       enableServiceLinks:
-                        description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                         type: boolean
                       ephemeralContainers:
-                        description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                         items:
-                          description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in the container. Cannot be updated.
                               items:
-                                description: EnvVar represents an environment variable present in a Container.
                                 properties:
                                   name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                     type: string
                                   valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
                                     properties:
                                       configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
                                         properties:
                                           key:
-                                            description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
                                             type: boolean
                                         required:
                                         - key
                                         type: object
                                       fieldRef:
-                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                         properties:
                                           containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
                                         type: object
                                       secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
                                         properties:
                                           key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
                                             type: boolean
                                         required:
                                         - key
@@ -4925,72 +3705,51 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                               items:
-                                description: EnvFromSource represents the source of a set of ConfigMaps
                                 properties:
                                   configMapRef:
-                                    description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap must be defined
                                         type: boolean
                                     type: object
                                   prefix:
-                                    description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
-                                    description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret must be defined
                                         type: boolean
                                     type: object
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                               type: string
                             lifecycle:
-                              description: Lifecycle is not allowed for ephemeral containers.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -4998,64 +3757,49 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -5063,31 +3807,25 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -5095,37 +3833,27 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: Probes are not allowed for ephemeral containers.
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -5133,114 +3861,86 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                               type: string
                             ports:
-                              description: Ports are not allowed for ephemeral containers.
                               items:
-                                description: ContainerPort represents a network port in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
-                                    description: What host IP to bind the external port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
                                 type: object
                               type: array
                             readinessProbe:
-                              description: Probes are not allowed for ephemeral containers.
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -5248,54 +3948,43 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             resources:
-                              description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                               properties:
                                 limits:
                                   additionalProperties:
@@ -5304,7 +3993,6 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -5313,113 +4001,80 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                               type: object
                             securityContext:
-                              description: SecurityContext is not allowed for ephemeral containers.
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                   properties:
                                     add:
-                                      description: Added capabilities
                                       items:
-                                        description: Capability represent POSIX capabilities type
                                         type: string
                                       type: array
                                     drop:
-                                      description: Removed capabilities
                                       items:
-                                        description: Capability represent POSIX capabilities type
                                         type: string
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only root filesystem. Default is false.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: Probes are not allowed for ephemeral containers.
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -5427,80 +4082,60 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                               type: boolean
                             targetContainerName:
-                              description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                               type: string
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                               type: boolean
                             volumeDevices:
-                              description: volumeDevices is the list of block devices to be used by the container.
                               items:
-                                description: volumeDevice describes a mapping of a raw block device within a container.
                                 properties:
                                   devicePath:
-                                    description: devicePath is the path inside of the container that the device will be mapped to.
                                     type: string
                                   name:
-                                    description: name must match the name of a persistentVolumeClaim in the pod
                                     type: string
                                 required:
                                 - devicePath
@@ -5508,27 +4143,19 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                               items:
-                                description: VolumeMount describes a mounting of a Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                     type: string
                                   name:
-                                    description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -5536,135 +4163,99 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
                       hostAliases:
-                        description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                         items:
-                          description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                           properties:
                             hostnames:
-                              description: Hostnames for the above IP address.
                               items:
                                 type: string
                               type: array
                             ip:
-                              description: IP address of the host file entry.
                               type: string
                           type: object
                         type: array
                       hostIPC:
-                        description: 'Use the host''s ipc namespace. Optional: Default to false.'
                         type: boolean
                       hostNetwork:
-                        description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                         type: boolean
                       hostPID:
-                        description: 'Use the host''s pid namespace. Optional: Default to false.'
                         type: boolean
                       hostname:
-                        description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                         type: string
                       imagePullSecrets:
-                        description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                         items:
-                          description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                           properties:
                             name:
-                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                               type: string
                           type: object
                         type: array
                       initContainers:
-                        description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                         items:
-                          description: A single application container that you want to run within a pod.
                           properties:
                             args:
-                              description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             command:
-                              description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                               items:
                                 type: string
                               type: array
                             env:
-                              description: List of environment variables to set in the container. Cannot be updated.
                               items:
-                                description: EnvVar represents an environment variable present in a Container.
                                 properties:
                                   name:
-                                    description: Name of the environment variable. Must be a C_IDENTIFIER.
                                     type: string
                                   value:
-                                    description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                     type: string
                                   valueFrom:
-                                    description: Source for the environment variable's value. Cannot be used if value is not empty.
                                     properties:
                                       configMapKeyRef:
-                                        description: Selects a key of a ConfigMap.
                                         properties:
                                           key:
-                                            description: The key to select.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its key must be defined
                                             type: boolean
                                         required:
                                         - key
                                         type: object
                                       fieldRef:
-                                        description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                         properties:
                                           containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
                                         type: object
                                       secretKeyRef:
-                                        description: Selects a key of a secret in the pod's namespace
                                         properties:
                                           key:
-                                            description: The key of the secret to select from.  Must be a valid secret key.
                                             type: string
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
                                             type: boolean
                                         required:
                                         - key
@@ -5675,72 +4266,51 @@ spec:
                                 type: object
                               type: array
                             envFrom:
-                              description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                               items:
-                                description: EnvFromSource represents the source of a set of ConfigMaps
                                 properties:
                                   configMapRef:
-                                    description: The ConfigMap to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap must be defined
                                         type: boolean
                                     type: object
                                   prefix:
-                                    description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                     type: string
                                   secretRef:
-                                    description: The Secret to select from
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the Secret must be defined
                                         type: boolean
                                     type: object
                                 type: object
                               type: array
                             image:
-                              description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                               type: string
                             imagePullPolicy:
-                              description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                               type: string
                             lifecycle:
-                              description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                               properties:
                                 postStart:
-                                  description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -5748,64 +4318,49 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
                                       type: object
                                   type: object
                                 preStop:
-                                  description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                   properties:
                                     exec:
-                                      description: One and only one of the following should be specified. Exec specifies the action to take.
                                       properties:
                                         command:
-                                          description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                           items:
                                             type: string
                                           type: array
                                       type: object
                                     httpGet:
-                                      description: HTTPGet specifies the http request to perform.
                                       properties:
                                         host:
-                                          description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                           type: string
                                         httpHeaders:
-                                          description: Custom headers to set in the request. HTTP allows repeated headers.
                                           items:
-                                            description: HTTPHeader describes a custom header to be used in HTTP probes
                                             properties:
                                               name:
-                                                description: The header field name
                                                 type: string
                                               value:
-                                                description: The header field value
                                                 type: string
                                             required:
                                             - name
@@ -5813,31 +4368,25 @@ spec:
                                             type: object
                                           type: array
                                         path:
-                                          description: Path to access on the HTTP server.
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                         scheme:
-                                          description: Scheme to use for connecting to the host. Defaults to HTTP.
                                           type: string
                                       required:
                                       - port
                                       type: object
                                     tcpSocket:
-                                      description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                       properties:
                                         host:
-                                          description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                           type: string
                                         port:
                                           anyOf:
                                           - type: integer
                                           - type: string
-                                          description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                           x-kubernetes-int-or-string: true
                                       required:
                                       - port
@@ -5845,37 +4394,27 @@ spec:
                                   type: object
                               type: object
                             livenessProbe:
-                              description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -5883,77 +4422,59 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             name:
-                              description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                               type: string
                             ports:
-                              description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                               items:
-                                description: ContainerPort represents a network port in a single container.
                                 properties:
                                   containerPort:
-                                    description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                     format: int32
                                     type: integer
                                   hostIP:
-                                    description: What host IP to bind the external port to.
                                     type: string
                                   hostPort:
-                                    description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                     format: int32
                                     type: integer
                                   name:
-                                    description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                     type: string
                                   protocol:
                                     default: TCP
-                                    description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                     type: string
                                 required:
                                 - containerPort
@@ -5964,37 +4485,27 @@ spec:
                               - protocol
                               x-kubernetes-list-type: map
                             readinessProbe:
-                              description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -6002,54 +4513,43 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             resources:
-                              description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                               properties:
                                 limits:
                                   additionalProperties:
@@ -6058,7 +4558,6 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                                 requests:
                                   additionalProperties:
@@ -6067,113 +4566,80 @@ spec:
                                     - type: string
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
-                                  description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                   type: object
                               type: object
                             securityContext:
-                              description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                               properties:
                                 allowPrivilegeEscalation:
-                                  description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                   type: boolean
                                 capabilities:
-                                  description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                   properties:
                                     add:
-                                      description: Added capabilities
                                       items:
-                                        description: Capability represent POSIX capabilities type
                                         type: string
                                       type: array
                                     drop:
-                                      description: Removed capabilities
                                       items:
-                                        description: Capability represent POSIX capabilities type
                                         type: string
                                       type: array
                                   type: object
                                 privileged:
-                                  description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                   type: boolean
                                 procMount:
-                                  description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                   type: string
                                 readOnlyRootFilesystem:
-                                  description: Whether this container has a read-only root filesystem. Default is false.
                                   type: boolean
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             startupProbe:
-                              description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                               properties:
                                 exec:
-                                  description: One and only one of the following should be specified. Exec specifies the action to take.
                                   properties:
                                     command:
-                                      description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                       items:
                                         type: string
                                       type: array
                                   type: object
                                 failureThreshold:
-                                  description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 httpGet:
-                                  description: HTTPGet specifies the http request to perform.
                                   properties:
                                     host:
-                                      description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                       type: string
                                     httpHeaders:
-                                      description: Custom headers to set in the request. HTTP allows repeated headers.
                                       items:
-                                        description: HTTPHeader describes a custom header to be used in HTTP probes
                                         properties:
                                           name:
-                                            description: The header field name
                                             type: string
                                           value:
-                                            description: The header field value
                                             type: string
                                         required:
                                         - name
@@ -6181,77 +4647,58 @@ spec:
                                         type: object
                                       type: array
                                     path:
-                                      description: Path to access on the HTTP server.
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                     scheme:
-                                      description: Scheme to use for connecting to the host. Defaults to HTTP.
                                       type: string
                                   required:
                                   - port
                                   type: object
                                 initialDelaySeconds:
-                                  description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                                 periodSeconds:
-                                  description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 successThreshold:
-                                  description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                   format: int32
                                   type: integer
                                 tcpSocket:
-                                  description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                   properties:
                                     host:
-                                      description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                       type: string
                                     port:
                                       anyOf:
                                       - type: integer
                                       - type: string
-                                      description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                       x-kubernetes-int-or-string: true
                                   required:
                                   - port
                                   type: object
                                 timeoutSeconds:
-                                  description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                   format: int32
                                   type: integer
                               type: object
                             stdin:
-                              description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                               type: boolean
                             stdinOnce:
-                              description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                               type: boolean
                             terminationMessagePath:
-                              description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                               type: string
                             terminationMessagePolicy:
-                              description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                               type: string
                             tty:
-                              description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                               type: boolean
                             volumeDevices:
-                              description: volumeDevices is the list of block devices to be used by the container.
                               items:
-                                description: volumeDevice describes a mapping of a raw block device within a container.
                                 properties:
                                   devicePath:
-                                    description: devicePath is the path inside of the container that the device will be mapped to.
                                     type: string
                                   name:
-                                    description: name must match the name of a persistentVolumeClaim in the pod
                                     type: string
                                 required:
                                 - devicePath
@@ -6259,27 +4706,19 @@ spec:
                                 type: object
                               type: array
                             volumeMounts:
-                              description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                               items:
-                                description: VolumeMount describes a mounting of a Volume within a container.
                                 properties:
                                   mountPath:
-                                    description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                     type: string
                                   mountPropagation:
-                                    description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                     type: string
                                   name:
-                                    description: This must match the Name of a Volume.
                                     type: string
                                   readOnly:
-                                    description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                     type: boolean
                                   subPath:
-                                    description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                     type: string
                                   subPathExpr:
-                                    description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                     type: string
                                 required:
                                 - mountPath
@@ -6287,19 +4726,16 @@ spec:
                                 type: object
                               type: array
                             workingDir:
-                              description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                               type: string
                           required:
                           - name
                           type: object
                         type: array
                       nodeName:
-                        description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                         type: string
                       nodeSelector:
                         additionalProperties:
                           type: string
-                        description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                         type: object
                       overhead:
                         additionalProperties:
@@ -6308,92 +4744,66 @@ spec:
                           - type: string
                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                           x-kubernetes-int-or-string: true
-                        description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                         type: object
                       preemptionPolicy:
-                        description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                         type: string
                       priority:
-                        description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                         format: int32
                         type: integer
                       priorityClassName:
-                        description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                         type: string
                       readinessGates:
-                        description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                         items:
-                          description: PodReadinessGate contains the reference to a pod condition
                           properties:
                             conditionType:
-                              description: ConditionType refers to a condition in the pod's condition list with matching type.
                               type: string
                           required:
                           - conditionType
                           type: object
                         type: array
                       restartPolicy:
-                        description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                         type: string
                       runtimeClassName:
-                        description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                         type: string
                       schedulerName:
-                        description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                         type: string
                       securityContext:
-                        description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                         properties:
                           fsGroup:
-                            description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                             format: int64
                             type: integer
                           fsGroupChangePolicy:
-                            description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                             type: string
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                             properties:
                               level:
-                                description: Level is SELinux level label that applies to the container.
                                 type: string
                               role:
-                                description: Role is a SELinux role label that applies to the container.
                                 type: string
                               type:
-                                description: Type is a SELinux type label that applies to the container.
                                 type: string
                               user:
-                                description: User is a SELinux user label that applies to the container.
                                 type: string
                             type: object
                           supplementalGroups:
-                            description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                             items:
                               format: int64
                               type: integer
                             type: array
                           sysctls:
-                            description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                             items:
-                              description: Sysctl defines a kernel parameter to be set
                               properties:
                                 name:
-                                  description: Name of a property to set
                                   type: string
                                 value:
-                                  description: Value of a property to set
                                   type: string
                               required:
                               - name
@@ -6401,79 +4811,55 @@ spec:
                               type: object
                             type: array
                           windowsOptions:
-                            description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
-                                description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                 type: string
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       serviceAccount:
-                        description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                         type: string
                       serviceAccountName:
-                        description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                         type: string
                       shareProcessNamespace:
-                        description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                         type: boolean
                       subdomain:
-                        description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                         type: string
                       terminationGracePeriodSeconds:
-                        description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                         format: int64
                         type: integer
                       tolerations:
-                        description: If specified, the pod's tolerations.
                         items:
-                          description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                           properties:
                             effect:
-                              description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                               type: string
                             key:
-                              description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                               type: string
                             operator:
-                              description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                               type: string
                             tolerationSeconds:
-                              description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                               format: int64
                               type: integer
                             value:
-                              description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                               type: string
                           type: object
                         type: array
                       topologySpreadConstraints:
-                        description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                         items:
-                          description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                           properties:
                             labelSelector:
-                              description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                               properties:
                                 matchExpressions:
-                                  description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                   items:
-                                    description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                     properties:
                                       key:
-                                        description: key is the label key that the selector applies to.
                                         type: string
                                       operator:
-                                        description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                         type: string
                                       values:
-                                        description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                         items:
                                           type: string
                                         type: array
@@ -6485,18 +4871,14 @@ spec:
                                 matchLabels:
                                   additionalProperties:
                                     type: string
-                                  description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                   type: object
                               type: object
                             maxSkew:
-                              description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                               format: int32
                               type: integer
                             topologyKey:
-                              description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                               type: string
                             whenUnsatisfiable:
-                              description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                               type: string
                           required:
                           - maxSkew
@@ -6509,143 +4891,104 @@ spec:
                         - whenUnsatisfiable
                         x-kubernetes-list-type: map
                       volumes:
-                        description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                         items:
-                          description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                           properties:
                             awsElasticBlockStore:
-                              description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: boolean
                                 volumeID:
-                                  description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             azureDisk:
-                              description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                               properties:
                                 cachingMode:
-                                  description: 'Host Caching mode: None, Read Only, Read Write.'
                                   type: string
                                 diskName:
-                                  description: The Name of the data disk in the blob storage
                                   type: string
                                 diskURI:
-                                  description: The URI the data disk in the blob storage
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 kind:
-                                  description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                               required:
                               - diskName
                               - diskURI
                               type: object
                             azureFile:
-                              description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                               properties:
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretName:
-                                  description: the name of secret that contains Azure Storage Account Name and Key
                                   type: string
                                 shareName:
-                                  description: Share Name
                                   type: string
                               required:
                               - secretName
                               - shareName
                               type: object
                             cephfs:
-                              description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                               properties:
                                 monitors:
-                                  description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 path:
-                                  description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: boolean
                                 secretFile:
-                                  description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                   type: string
                               required:
                               - monitors
                               type: object
                             cinder:
-                              description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeID:
-                                  description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                   type: string
                               required:
                               - volumeID
                               type: object
                             configMap:
-                              description: ConfigMap represents a configMap that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -6653,85 +4996,63 @@ spec:
                                     type: object
                                   type: array
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                   type: string
                                 optional:
-                                  description: Specify whether the ConfigMap or its keys must be defined
                                   type: boolean
                               type: object
                             csi:
-                              description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                               properties:
                                 driver:
-                                  description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                   type: string
                                 nodePublishSecretRef:
-                                  description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 readOnly:
-                                  description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                                   type: boolean
                                 volumeAttributes:
                                   additionalProperties:
                                     type: string
-                                  description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                   type: object
                               required:
                               - driver
                               type: object
                             downwardAPI:
-                              description: DownwardAPI represents downward API about the pod that should populate this volume
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: Items is a list of downward API volume file
                                   items:
-                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                     properties:
                                       fieldRef:
-                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                         properties:
                                           apiVersion:
-                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                             type: string
                                           fieldPath:
-                                            description: Path of the field to select in the specified API version.
                                             type: string
                                         required:
                                         - fieldPath
                                         type: object
                                       mode:
-                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                         type: string
                                       resourceFieldRef:
-                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                         properties:
                                           containerName:
-                                            description: 'Container name: required for volumes, optional for env vars'
                                             type: string
                                           divisor:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                             x-kubernetes-int-or-string: true
                                           resource:
-                                            description: 'Required: resource to select'
                                             type: string
                                         required:
                                         - resource
@@ -6742,184 +5063,136 @@ spec:
                                   type: array
                               type: object
                             emptyDir:
-                              description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                               properties:
                                 medium:
-                                  description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                   type: string
                                 sizeLimit:
                                   anyOf:
                                   - type: integer
                                   - type: string
-                                  description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
                               type: object
                             fc:
-                              description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                               properties:
                                 fsType:
-                                  description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 lun:
-                                  description: 'Optional: FC target lun number'
                                   format: int32
                                   type: integer
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 targetWWNs:
-                                  description: 'Optional: FC target worldwide names (WWNs)'
                                   items:
                                     type: string
                                   type: array
                                 wwids:
-                                  description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                   items:
                                     type: string
                                   type: array
                               type: object
                             flexVolume:
-                              description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                               properties:
                                 driver:
-                                  description: Driver is the name of the driver to use for this volume.
                                   type: string
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                   type: string
                                 options:
                                   additionalProperties:
                                     type: string
-                                  description: 'Optional: Extra command options if any.'
                                   type: object
                                 readOnly:
-                                  description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                   type: boolean
                                 secretRef:
-                                  description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                               required:
                               - driver
                               type: object
                             flocker:
-                              description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                               properties:
                                 datasetName:
-                                  description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                   type: string
                                 datasetUUID:
-                                  description: UUID of the dataset. This is unique identifier of a Flocker dataset
                                   type: string
                               type: object
                             gcePersistentDisk:
-                              description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 partition:
-                                  description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   format: int32
                                   type: integer
                                 pdName:
-                                  description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                   type: boolean
                               required:
                               - pdName
                               type: object
                             gitRepo:
-                              description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                               properties:
                                 directory:
-                                  description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                   type: string
                                 repository:
-                                  description: Repository URL
                                   type: string
                                 revision:
-                                  description: Commit hash for the specified revision.
                                   type: string
                               required:
                               - repository
                               type: object
                             glusterfs:
-                              description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                               properties:
                                 endpoints:
-                                  description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 path:
-                                  description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                   type: boolean
                               required:
                               - endpoints
                               - path
                               type: object
                             hostPath:
-                              description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                               properties:
                                 path:
-                                  description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                                 type:
-                                  description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                   type: string
                               required:
                               - path
                               type: object
                             iscsi:
-                              description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                               properties:
                                 chapAuthDiscovery:
-                                  description: whether support iSCSI Discovery CHAP authentication
                                   type: boolean
                                 chapAuthSession:
-                                  description: whether support iSCSI Session CHAP authentication
                                   type: boolean
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 initiatorName:
-                                  description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                   type: string
                                 iqn:
-                                  description: Target iSCSI Qualified Name.
                                   type: string
                                 iscsiInterface:
-                                  description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                   type: string
                                 lun:
-                                  description: iSCSI Target Lun number.
                                   format: int32
                                   type: integer
                                 portals:
-                                  description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   items:
                                     type: string
                                   type: array
                                 readOnly:
-                                  description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                   type: boolean
                                 secretRef:
-                                  description: CHAP Secret for iSCSI target and initiator authentication
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 targetPortal:
-                                  description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                   type: string
                               required:
                               - iqn
@@ -6927,92 +5200,67 @@ spec:
                               - targetPortal
                               type: object
                             name:
-                              description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                             nfs:
-                              description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                               properties:
                                 path:
-                                  description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: boolean
                                 server:
-                                  description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                   type: string
                               required:
                               - path
                               - server
                               type: object
                             persistentVolumeClaim:
-                              description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                               properties:
                                 claimName:
-                                  description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                   type: string
                                 readOnly:
-                                  description: Will force the ReadOnly setting in VolumeMounts. Default false.
                                   type: boolean
                               required:
                               - claimName
                               type: object
                             photonPersistentDisk:
-                              description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 pdID:
-                                  description: ID that identifies Photon Controller persistent disk
                                   type: string
                               required:
                               - pdID
                               type: object
                             portworxVolume:
-                              description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 volumeID:
-                                  description: VolumeID uniquely identifies a Portworx volume
                                   type: string
                               required:
                               - volumeID
                               type: object
                             projected:
-                              description: Items for all in one resources secrets, configmaps, and downward API
                               properties:
                                 defaultMode:
-                                  description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 sources:
-                                  description: list of volume projections
                                   items:
-                                    description: Projection that may be projected along with other supported volume types
                                     properties:
                                       configMap:
-                                        description: information about the configMap data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -7020,54 +5268,40 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the ConfigMap or its keys must be defined
                                             type: boolean
                                         type: object
                                       downwardAPI:
-                                        description: information about the downwardAPI data to project
                                         properties:
                                           items:
-                                            description: Items is a list of DownwardAPIVolume file
                                             items:
-                                              description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                               properties:
                                                 fieldRef:
-                                                  description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                   properties:
                                                     apiVersion:
-                                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                       type: string
                                                     fieldPath:
-                                                      description: Path of the field to select in the specified API version.
                                                       type: string
                                                   required:
                                                   - fieldPath
                                                   type: object
                                                 mode:
-                                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                   type: string
                                                 resourceFieldRef:
-                                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                                   properties:
                                                     containerName:
-                                                      description: 'Container name: required for volumes, optional for env vars'
                                                       type: string
                                                     divisor:
                                                       anyOf:
                                                       - type: integer
                                                       - type: string
-                                                      description: Specifies the output format of the exposed resources, defaults to "1"
                                                       pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                       x-kubernetes-int-or-string: true
                                                     resource:
-                                                      description: 'Required: resource to select'
                                                       type: string
                                                   required:
                                                   - resource
@@ -7078,22 +5312,16 @@ spec:
                                             type: array
                                         type: object
                                       secret:
-                                        description: information about the secret data to project
                                         properties:
                                           items:
-                                            description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                             items:
-                                              description: Maps a string key to a path within a volume.
                                               properties:
                                                 key:
-                                                  description: The key to project.
                                                   type: string
                                                 mode:
-                                                  description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                   format: int32
                                                   type: integer
                                                 path:
-                                                  description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                   type: string
                                               required:
                                               - key
@@ -7101,24 +5329,18 @@ spec:
                                               type: object
                                             type: array
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                           optional:
-                                            description: Specify whether the Secret or its key must be defined
                                             type: boolean
                                         type: object
                                       serviceAccountToken:
-                                        description: information about the serviceAccountToken data to project
                                         properties:
                                           audience:
-                                            description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                             type: string
                                           expirationSeconds:
-                                            description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                             format: int64
                                             type: integer
                                           path:
-                                            description: Path is the path relative to the mount point of the file to project the token into.
                                             type: string
                                         required:
                                         - path
@@ -7129,103 +5351,74 @@ spec:
                               - sources
                               type: object
                             quobyte:
-                              description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                               properties:
                                 group:
-                                  description: Group to map volume access to Default is no group
                                   type: string
                                 readOnly:
-                                  description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                   type: boolean
                                 registry:
-                                  description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                   type: string
                                 tenant:
-                                  description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                   type: string
                                 user:
-                                  description: User to map volume access to Defaults to serivceaccount user
                                   type: string
                                 volume:
-                                  description: Volume is a string that references an already created Quobyte volume by name.
                                   type: string
                               required:
                               - registry
                               - volume
                               type: object
                             rbd:
-                              description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                               properties:
                                 fsType:
-                                  description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                   type: string
                                 image:
-                                  description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 keyring:
-                                  description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 monitors:
-                                  description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   items:
                                     type: string
                                   type: array
                                 pool:
-                                  description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                                 readOnly:
-                                  description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: boolean
                                 secretRef:
-                                  description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 user:
-                                  description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                   type: string
                               required:
                               - image
                               - monitors
                               type: object
                             scaleIO:
-                              description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                   type: string
                                 gateway:
-                                  description: The host address of the ScaleIO API Gateway.
                                   type: string
                                 protectionDomain:
-                                  description: The name of the ScaleIO Protection Domain for the configured storage.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 sslEnabled:
-                                  description: Flag to enable/disable SSL communication with Gateway, default false
                                   type: boolean
                                 storageMode:
-                                  description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                   type: string
                                 storagePool:
-                                  description: The ScaleIO Storage Pool associated with the protection domain.
                                   type: string
                                 system:
-                                  description: The name of the storage system as configured in ScaleIO.
                                   type: string
                                 volumeName:
-                                  description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                                   type: string
                               required:
                               - gateway
@@ -7233,26 +5426,19 @@ spec:
                               - system
                               type: object
                             secret:
-                              description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                               properties:
                                 defaultMode:
-                                  description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                   format: int32
                                   type: integer
                                 items:
-                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                   items:
-                                    description: Maps a string key to a path within a volume.
                                     properties:
                                       key:
-                                        description: The key to project.
                                         type: string
                                       mode:
-                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       path:
-                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                         type: string
                                     required:
                                     - key
@@ -7260,49 +5446,35 @@ spec:
                                     type: object
                                   type: array
                                 optional:
-                                  description: Specify whether the Secret or its keys must be defined
                                   type: boolean
                                 secretName:
-                                  description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                   type: string
                               type: object
                             storageos:
-                              description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 readOnly:
-                                  description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                   type: boolean
                                 secretRef:
-                                  description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                   properties:
                                     name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                       type: string
                                   type: object
                                 volumeName:
-                                  description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                   type: string
                                 volumeNamespace:
-                                  description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                   type: string
                               type: object
                             vsphereVolume:
-                              description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                               properties:
                                 fsType:
-                                  description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                   type: string
                                 storagePolicyID:
-                                  description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                   type: string
                                 storagePolicyName:
-                                  description: Storage Policy Based Management (SPBM) profile name.
                                   type: string
                                 volumePath:
-                                  description: Path that identifies vSphere volume vmdk
                                   type: string
                               required:
                               - volumePath
@@ -7316,43 +5488,32 @@ spec:
                     type: object
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.
                 format: int32
                 type: integer
             required:
             - mpiReplicaSpecs
             type: object
           status:
-            description: JobStatus represents the current observed state of the training Job.
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               conditions:
-                description: Conditions is an array of current observed job conditions.
                 items:
-                  description: JobCondition describes the state of the job at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of job condition.
                       type: string
                   required:
                   - status
@@ -7360,34 +5521,26 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
                 additionalProperties:
-                  description: ReplicaStatus represents the current observed state of the replica.
                   properties:
                     active:
-                      description: The number of actively running pods.
                       format: int32
                       type: integer
                     evicted:
-                      description: The number of pods which reached phase Failed and reason is Evicted, it is included in the number of Failed.
                       format: int32
                       type: integer
                     failed:
-                      description: The number of pods which reached phase Failed.
                       format: int32
                       type: integer
                     succeeded:
-                      description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             required:

--- a/config/crd/bases/kubeflow.org_pytorchjobs.yaml
+++ b/config/crd/bases/kubeflow.org_pytorchjobs.yaml
@@ -32,82 +32,57 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: Represents a PyTorchJob resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
-            description: Standard Kubernetes object's metadata.
             type: object
           spec:
-            description: Specification of the desired state of the PyTorchJob.
             properties:
               activeDeadlineSeconds:
-                description: Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
                 format: int64
                 type: integer
               backoffLimit:
-                description: Optional number of retries before marking this job failed.
                 format: int32
                 type: integer
               cleanPodPolicy:
-                description: CleanPodPolicy defines the policy to kill pods after the job completes. Default to Running.
                 type: string
               pytorchReplicaSpecs:
                 additionalProperties:
-                  description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job. One of Always, OnFailure, Never and ExitCode. Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that will be created for this replica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
-                              description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -117,18 +92,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -139,7 +109,6 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -148,26 +117,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -177,18 +138,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -204,32 +160,22 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -241,22 +187,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -265,26 +207,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -296,16 +230,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -313,32 +244,22 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -350,22 +271,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -374,26 +291,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -405,16 +314,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -423,94 +329,69 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -521,72 +402,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -594,64 +454,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -659,31 +504,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -691,37 +530,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -729,77 +558,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -810,37 +621,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -848,54 +649,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -904,7 +694,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -913,113 +702,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1027,77 +783,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1105,27 +842,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1133,130 +862,97 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
                                         type: string
                                       value:
                                         type: string
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1267,72 +963,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1340,64 +1015,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1405,31 +1065,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1437,37 +1091,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1475,114 +1119,86 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1590,54 +1206,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1646,7 +1251,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1655,113 +1259,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1769,80 +1340,60 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1850,27 +1401,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1878,135 +1421,99 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                                 properties:
                                   hostnames:
-                                    description: Hostnames for the above IP address.
                                     items:
                                       type: string
                                     type: array
                                   ip:
-                                    description: IP address of the host file entry.
                                     type: string
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2017,72 +1524,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2090,64 +1576,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2155,31 +1626,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2187,37 +1652,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2225,77 +1680,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2306,37 +1743,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2344,54 +1771,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2400,7 +1816,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2409,113 +1824,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2523,77 +1905,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2601,27 +1964,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2629,19 +1984,16 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -2650,92 +2002,66 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
                                     properties:
                                       name:
-                                        description: Name of a property to set
                                         type: string
                                       value:
-                                        description: Value of a property to set
                                         type: string
                                     required:
                                     - name
@@ -2743,79 +2069,55 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
-                              description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2827,18 +2129,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -2851,143 +2149,104 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
-                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains Azure Storage Account Name and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -2995,85 +2254,63 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: Items is a list of downward API volume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
@@ -3084,184 +2321,136 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -3269,92 +2458,67 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
                                         items:
-                                          description: Projection that may be projected along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3362,54 +2526,40 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its keys must be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI data to project
                                               properties:
                                                 items:
-                                                  description: Items is a list of DownwardAPIVolume file
                                                   items:
-                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                     properties:
                                                       fieldRef:
-                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                         properties:
                                                           apiVersion:
-                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                             type: string
                                                           fieldPath:
-                                                            description: Path of the field to select in the specified API version.
                                                             type: string
                                                         required:
                                                         - fieldPath
                                                         type: object
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                                         properties:
                                                           containerName:
-                                                            description: 'Container name: required for volumes, optional for env vars'
                                                             type: string
                                                           divisor:
                                                             anyOf:
                                                             - type: integer
                                                             - type: string
-                                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                             x-kubernetes-int-or-string: true
                                                           resource:
-                                                            description: 'Required: resource to select'
                                                             type: string
                                                         required:
                                                         - resource
@@ -3420,22 +2570,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3443,24 +2587,18 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative to the mount point of the file to project the token into.
                                                   type: string
                                               required:
                                               - path
@@ -3471,103 +2609,74 @@ spec:
                                     - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references an already created Quobyte volume by name.
                                         type: string
                                     required:
                                     - registry
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection Domain for the configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication with Gateway, default false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -3575,26 +2684,19 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3602,49 +2704,35 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -3658,53 +2746,40 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'A map of PyTorchReplicaType (type) to ReplicaSpec (value). Specifies the PyTorch cluster configuration. For example,   {     "Master": PyTorchReplicaSpec,     "Worker": PyTorchReplicaSpec,   }'
                 type: object
               schedulingPolicy:
-                description: SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling
                 properties:
                   minAvailable:
                     format: int32
                     type: integer
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.
                 format: int32
                 type: integer
             required:
             - pytorchReplicaSpecs
             type: object
           status:
-            description: Most recently observed status of the PyTorchJob. Read-only (modified by the system).
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               conditions:
-                description: Conditions is an array of current observed job conditions.
                 items:
-                  description: JobCondition describes the state of the job at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of job condition.
                       type: string
                   required:
                   - status
@@ -3712,34 +2787,26 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
                 additionalProperties:
-                  description: ReplicaStatus represents the current observed state of the replica.
                   properties:
                     active:
-                      description: The number of actively running pods.
                       format: int32
                       type: integer
                     evicted:
-                      description: The number of pods which reached phase Failed and reason is Evicted, it is included in the number of Failed.
                       format: int32
                       type: integer
                     failed:
-                      description: The number of pods which reached phase Failed.
                       format: int32
                       type: integer
                     succeeded:
-                      description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             required:

--- a/config/crd/bases/kubeflow.org_tfjobs.yaml
+++ b/config/crd/bases/kubeflow.org_tfjobs.yaml
@@ -32,92 +32,65 @@ spec:
     name: v1
     schema:
       openAPIV3Schema:
-        description: TFJob represents a TFJob resource.
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
-            description: Standard Kubernetes object's metadata.
             type: object
           spec:
-            description: Specification of the desired state of the TFJob.
             properties:
               activeDeadlineSeconds:
-                description: Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
                 format: int64
                 type: integer
               backoffLimit:
-                description: Optional number of retries before marking this job failed.
                 format: int32
                 type: integer
               cleanPodPolicy:
-                description: CleanPodPolicy defines the policy to kill pods after the job completes. Default to Running.
                 type: string
               schedulingPolicy:
-                description: SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling
                 properties:
                   minAvailable:
                     format: int32
                     type: integer
                 type: object
               successPolicy:
-                description: SuccessPolicy defines the policy to mark the TFJob as succeeded when the job does not contain chief or master role. Value "" means the default policy that the job is succeeded if all workers are succeeded or worker 0 completed, Value "AllWorkers" means the job is succeeded if all workers are succeeded. Default to ""
                 type: string
               tfReplicaSpecs:
                 additionalProperties:
-                  description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job. One of Always, OnFailure, Never and ExitCode. Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that will be created for this replica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
-                              description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -127,18 +100,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -149,7 +117,6 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -158,26 +125,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -187,18 +146,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -214,32 +168,22 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -251,22 +195,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -275,26 +215,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -306,16 +238,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -323,32 +252,22 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -360,22 +279,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -384,26 +299,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -415,16 +322,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -433,94 +337,69 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -531,72 +410,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -604,64 +462,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -669,31 +512,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -701,37 +538,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -739,77 +566,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -820,37 +629,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -858,54 +657,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -914,7 +702,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -923,113 +710,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1037,77 +791,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1115,27 +850,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1143,130 +870,97 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
                                         type: string
                                       value:
                                         type: string
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1277,72 +971,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1350,64 +1023,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1415,31 +1073,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1447,37 +1099,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1485,114 +1127,86 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1600,54 +1214,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1656,7 +1259,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1665,113 +1267,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1779,80 +1348,60 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1860,27 +1409,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1888,135 +1429,99 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                                 properties:
                                   hostnames:
-                                    description: Hostnames for the above IP address.
                                     items:
                                       type: string
                                     type: array
                                   ip:
-                                    description: IP address of the host file entry.
                                     type: string
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2027,72 +1532,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2100,64 +1584,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2165,31 +1634,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2197,37 +1660,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2235,77 +1688,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2316,37 +1751,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2354,54 +1779,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2410,7 +1824,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2419,113 +1832,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2533,77 +1913,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2611,27 +1972,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2639,19 +1992,16 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -2660,92 +2010,66 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
                                     properties:
                                       name:
-                                        description: Name of a property to set
                                         type: string
                                       value:
-                                        description: Value of a property to set
                                         type: string
                                     required:
                                     - name
@@ -2753,79 +2077,55 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
-                              description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2837,18 +2137,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -2861,143 +2157,104 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
-                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains Azure Storage Account Name and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3005,85 +2262,63 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: Items is a list of downward API volume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
@@ -3094,184 +2329,136 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -3279,92 +2466,67 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
                                         items:
-                                          description: Projection that may be projected along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3372,54 +2534,40 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its keys must be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI data to project
                                               properties:
                                                 items:
-                                                  description: Items is a list of DownwardAPIVolume file
                                                   items:
-                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                     properties:
                                                       fieldRef:
-                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                         properties:
                                                           apiVersion:
-                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                             type: string
                                                           fieldPath:
-                                                            description: Path of the field to select in the specified API version.
                                                             type: string
                                                         required:
                                                         - fieldPath
                                                         type: object
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                                         properties:
                                                           containerName:
-                                                            description: 'Container name: required for volumes, optional for env vars'
                                                             type: string
                                                           divisor:
                                                             anyOf:
                                                             - type: integer
                                                             - type: string
-                                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                             x-kubernetes-int-or-string: true
                                                           resource:
-                                                            description: 'Required: resource to select'
                                                             type: string
                                                         required:
                                                         - resource
@@ -3430,22 +2578,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3453,24 +2595,18 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative to the mount point of the file to project the token into.
                                                   type: string
                                               required:
                                               - path
@@ -3481,103 +2617,74 @@ spec:
                                     - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references an already created Quobyte volume by name.
                                         type: string
                                     required:
                                     - registry
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection Domain for the configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication with Gateway, default false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -3585,26 +2692,19 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3612,49 +2712,35 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -3668,46 +2754,34 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'A map of TFReplicaType (type) to ReplicaSpec (value). Specifies the TF cluster configuration. For example,   {     "PS": ReplicaSpec,     "Worker": ReplicaSpec,   }'
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.
                 format: int32
                 type: integer
             required:
             - tfReplicaSpecs
             type: object
           status:
-            description: Most recently observed status of the TFJob. Read-only (modified by the system).
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               conditions:
-                description: Conditions is an array of current observed job conditions.
                 items:
-                  description: JobCondition describes the state of the job at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of job condition.
                       type: string
                   required:
                   - status
@@ -3715,34 +2789,26 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
                 additionalProperties:
-                  description: ReplicaStatus represents the current observed state of the replica.
                   properties:
                     active:
-                      description: The number of actively running pods.
                       format: int32
                       type: integer
                     evicted:
-                      description: The number of pods which reached phase Failed and reason is Evicted, it is included in the number of Failed.
                       format: int32
                       type: integer
                     failed:
-                      description: The number of pods which reached phase Failed.
                       format: int32
                       type: integer
                     succeeded:
-                      description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             required:

--- a/config/crd/bases/xdl.kubedl.io_xdljobs.yaml
+++ b/config/crd/bases/xdl.kubedl.io_xdljobs.yaml
@@ -32,100 +32,72 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: XDLJob is the Schema for the xdljobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: XDLJobSpec defines the desired state of XDLJob
             properties:
               activeDeadlineSeconds:
-                description: Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
                 format: int64
                 type: integer
               backoffLimit:
-                description: Optional number of retries before marking this job failed.
                 format: int32
                 type: integer
               cleanPodPolicy:
-                description: CleanPodPolicy defines the policy to kill pods after the job completes. Default to Running.
                 type: string
               minFinishWorkNum:
-                description: MinFinishWorkerNum specifies the minimum number of successfully finished workers such that the job is treated as successful. Not specifying this value means all worker should be successfully finished.
                 format: int32
                 type: integer
               minFinishWorkRate:
-                description: MinFinishWorkPercentage specifies the minimum percentage of all workers that should be finished successfully such that the job is treated as successful. MinFinishWorkPercentage takes precedence over  MinFinishWorkerNum if both are specified.
                 format: int32
                 type: integer
               schedulingPolicy:
-                description: SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling
                 properties:
                   minAvailable:
                     format: int32
                     type: integer
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.
                 format: int32
                 type: integer
               xdlReplicaSpecs:
                 additionalProperties:
-                  description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job. One of Always, OnFailure, Never and ExitCode. Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that will be created for this replica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
-                              description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -135,18 +107,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -157,7 +124,6 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -166,26 +132,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -195,18 +153,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -222,32 +175,22 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -259,22 +202,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -283,26 +222,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -314,16 +245,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -331,32 +259,22 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -368,22 +286,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -392,26 +306,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -423,16 +329,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -441,94 +344,69 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -539,72 +417,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -612,64 +469,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -677,31 +519,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -709,37 +545,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -747,77 +573,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -828,37 +636,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -866,54 +664,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -922,7 +709,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -931,113 +717,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1045,77 +798,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1123,27 +857,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1151,130 +877,97 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
                                         type: string
                                       value:
                                         type: string
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1285,72 +978,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1358,64 +1030,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1423,31 +1080,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1455,37 +1106,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1493,114 +1134,86 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1608,54 +1221,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1664,7 +1266,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1673,113 +1274,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1787,80 +1355,60 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1868,27 +1416,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1896,135 +1436,99 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                                 properties:
                                   hostnames:
-                                    description: Hostnames for the above IP address.
                                     items:
                                       type: string
                                     type: array
                                   ip:
-                                    description: IP address of the host file entry.
                                     type: string
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2035,72 +1539,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2108,64 +1591,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2173,31 +1641,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2205,37 +1667,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2243,77 +1695,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2324,37 +1758,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2362,54 +1786,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2418,7 +1831,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2427,113 +1839,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2541,77 +1920,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2619,27 +1979,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2647,19 +1999,16 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -2668,92 +2017,66 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
                                     properties:
                                       name:
-                                        description: Name of a property to set
                                         type: string
                                       value:
-                                        description: Value of a property to set
                                         type: string
                                     required:
                                     - name
@@ -2761,79 +2084,55 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
-                              description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2845,18 +2144,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -2869,143 +2164,104 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
-                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains Azure Storage Account Name and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3013,85 +2269,63 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: Items is a list of downward API volume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
@@ -3102,184 +2336,136 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -3287,92 +2473,67 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
                                         items:
-                                          description: Projection that may be projected along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3380,54 +2541,40 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its keys must be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI data to project
                                               properties:
                                                 items:
-                                                  description: Items is a list of DownwardAPIVolume file
                                                   items:
-                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                     properties:
                                                       fieldRef:
-                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                         properties:
                                                           apiVersion:
-                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                             type: string
                                                           fieldPath:
-                                                            description: Path of the field to select in the specified API version.
                                                             type: string
                                                         required:
                                                         - fieldPath
                                                         type: object
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                                         properties:
                                                           containerName:
-                                                            description: 'Container name: required for volumes, optional for env vars'
                                                             type: string
                                                           divisor:
                                                             anyOf:
                                                             - type: integer
                                                             - type: string
-                                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                             x-kubernetes-int-or-string: true
                                                           resource:
-                                                            description: 'Required: resource to select'
                                                             type: string
                                                         required:
                                                         - resource
@@ -3438,22 +2585,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3461,24 +2602,18 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative to the mount point of the file to project the token into.
                                                   type: string
                                               required:
                                               - path
@@ -3489,103 +2624,74 @@ spec:
                                     - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references an already created Quobyte volume by name.
                                         type: string
                                     required:
                                     - registry
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection Domain for the configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication with Gateway, default false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -3593,26 +2699,19 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3620,49 +2719,35 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -3676,42 +2761,31 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'XDLReplicaSpecs is map of ReplicaType and ReplicaSpec specifies the XDL replicas to run. For example,   {     "PS": ReplicaSpec,     "Worker": ReplicaSpec,   }'
                 type: object
             required:
             - xdlReplicaSpecs
             type: object
           status:
-            description: JobStatus represents the current observed state of the training Job.
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               conditions:
-                description: Conditions is an array of current observed job conditions.
                 items:
-                  description: JobCondition describes the state of the job at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of job condition.
                       type: string
                   required:
                   - status
@@ -3719,34 +2793,26 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
                 additionalProperties:
-                  description: ReplicaStatus represents the current observed state of the replica.
                   properties:
                     active:
-                      description: The number of actively running pods.
                       format: int32
                       type: integer
                     evicted:
-                      description: The number of pods which reached phase Failed and reason is Evicted, it is included in the number of Failed.
                       format: int32
                       type: integer
                     failed:
-                      description: The number of pods which reached phase Failed.
                       format: int32
                       type: integer
                     succeeded:
-                      description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             required:

--- a/config/crd/bases/xgboostjob.kubeflow.org_xgboostjobs.yaml
+++ b/config/crd/bases/xgboostjob.kubeflow.org_xgboostjobs.yaml
@@ -32,92 +32,66 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: XGBoostJob is the Schema for the xgboostjobs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
             type: string
           metadata:
             type: object
           spec:
-            description: XGBoostJobSpec defines the desired state of XGBoostJob
             properties:
               activeDeadlineSeconds:
-                description: Specifies the duration in seconds relative to the startTime that the job may be active before the system tries to terminate it; value must be positive integer.
                 format: int64
                 type: integer
               backoffLimit:
-                description: Optional number of retries before marking this job failed.
                 format: int32
                 type: integer
               cleanPodPolicy:
-                description: CleanPodPolicy defines the policy to kill pods after the job completes. Default to Running.
                 type: string
               schedulingPolicy:
-                description: SchedulingPolicy defines the policy related to scheduling, e.g. gang-scheduling
                 properties:
                   minAvailable:
                     format: int32
                     type: integer
                 type: object
               ttlSecondsAfterFinished:
-                description: TTLSecondsAfterFinished is the TTL to clean up jobs. It may take extra ReconcilePeriod seconds for the cleanup, since reconcile gets called periodically. Default to infinite.
                 format: int32
                 type: integer
               xgbReplicaSpecs:
                 additionalProperties:
-                  description: ReplicaSpec is a description of the replica
                   properties:
                     replicas:
-                      description: Replicas is the desired number of replicas of the given template. If unspecified, defaults to 1.
                       format: int32
                       type: integer
                     restartPolicy:
-                      description: Restart policy for all replicas within the job. One of Always, OnFailure, Never and ExitCode. Default to Never.
                       type: string
                     template:
-                      description: Template is the object that describes the pod that will be created for this replica. RestartPolicy in PodTemplateSpec will be overide by RestartPolicy in ReplicaSpec
                       properties:
                         metadata:
-                          description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
                           type: object
                         spec:
-                          description: 'Specification of the desired behavior of the pod. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
                           properties:
                             activeDeadlineSeconds:
-                              description: Optional duration in seconds the pod may be active on the node relative to StartTime before the system will actively try to mark it failed and kill associated containers. Value must be a positive integer.
                               format: int64
                               type: integer
                             affinity:
-                              description: If specified, the pod's scheduling constraints
                               properties:
                                 nodeAffinity:
-                                  description: Describes node affinity scheduling rules for the pod.
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                         properties:
                                           preference:
-                                            description: A node selector term, associated with the corresponding weight.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -127,18 +101,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -149,7 +118,6 @@ spec:
                                                 type: array
                                             type: object
                                           weight:
-                                            description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -158,26 +126,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
                                       properties:
                                         nodeSelectorTerms:
-                                          description: Required. A list of node selector terms. The terms are ORed.
                                           items:
-                                            description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                             properties:
                                               matchExpressions:
-                                                description: A list of node selector requirements by node's labels.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -187,18 +147,13 @@ spec:
                                                   type: object
                                                 type: array
                                               matchFields:
-                                                description: A list of node selector requirements by node's fields.
                                                 items:
-                                                  description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: The label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                                       type: string
                                                     values:
-                                                      description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -214,32 +169,22 @@ spec:
                                       type: object
                                   type: object
                                 podAffinity:
-                                  description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -251,22 +196,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -275,26 +216,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -306,16 +239,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -323,32 +253,22 @@ spec:
                                       type: array
                                   type: object
                                 podAntiAffinity:
-                                  description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
                                   properties:
                                     preferredDuringSchedulingIgnoredDuringExecution:
-                                      description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
                                       items:
-                                        description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
                                         properties:
                                           podAffinityTerm:
-                                            description: Required. A pod affinity term, associated with the corresponding weight.
                                             properties:
                                               labelSelector:
-                                                description: A label query over a set of resources, in this case pods.
                                                 properties:
                                                   matchExpressions:
-                                                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                     items:
-                                                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                       properties:
                                                         key:
-                                                          description: key is the label key that the selector applies to.
                                                           type: string
                                                         operator:
-                                                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                           type: string
                                                         values:
-                                                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                           items:
                                                             type: string
                                                           type: array
@@ -360,22 +280,18 @@ spec:
                                                   matchLabels:
                                                     additionalProperties:
                                                       type: string
-                                                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                     type: object
                                                 type: object
                                               namespaces:
-                                                description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                                 items:
                                                   type: string
                                                 type: array
                                               topologyKey:
-                                                description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                                 type: string
                                             required:
                                             - topologyKey
                                             type: object
                                           weight:
-                                            description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
                                             format: int32
                                             type: integer
                                         required:
@@ -384,26 +300,18 @@ spec:
                                         type: object
                                       type: array
                                     requiredDuringSchedulingIgnoredDuringExecution:
-                                      description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
                                       items:
-                                        description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
                                         properties:
                                           labelSelector:
-                                            description: A label query over a set of resources, in this case pods.
                                             properties:
                                               matchExpressions:
-                                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                                   properties:
                                                     key:
-                                                      description: key is the label key that the selector applies to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                                       items:
                                                         type: string
                                                       type: array
@@ -415,16 +323,13 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
                                           namespaces:
-                                            description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
                                             items:
                                               type: string
                                             type: array
                                           topologyKey:
-                                            description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
                                             type: string
                                         required:
                                         - topologyKey
@@ -433,94 +338,69 @@ spec:
                                   type: object
                               type: object
                             automountServiceAccountToken:
-                              description: AutomountServiceAccountToken indicates whether a service account token should be automatically mounted.
                               type: boolean
                             containers:
-                              description: List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -531,72 +411,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -604,64 +463,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -669,31 +513,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -701,37 +539,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -739,77 +567,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -820,37 +630,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -858,54 +658,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -914,7 +703,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -923,113 +711,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1037,77 +792,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1115,27 +851,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1143,130 +871,97 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             dnsConfig:
-                              description: Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.
                               properties:
                                 nameservers:
-                                  description: A list of DNS name server IP addresses. This will be appended to the base nameservers generated from DNSPolicy. Duplicated nameservers will be removed.
                                   items:
                                     type: string
                                   type: array
                                 options:
-                                  description: A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.
                                   items:
-                                    description: PodDNSConfigOption defines DNS resolver options of a pod.
                                     properties:
                                       name:
-                                        description: Required.
                                         type: string
                                       value:
                                         type: string
                                     type: object
                                   type: array
                                 searches:
-                                  description: A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.
                                   items:
                                     type: string
                                   type: array
                               type: object
                             dnsPolicy:
-                              description: Set DNS policy for the pod. Defaults to "ClusterFirst". Valid values are 'ClusterFirstWithHostNet', 'ClusterFirst', 'Default' or 'None'. DNS parameters given in DNSConfig will be merged with the policy selected with DNSPolicy. To have DNS options set along with hostNetwork, you have to specify DNS policy explicitly to 'ClusterFirstWithHostNet'.
                               type: string
                             enableServiceLinks:
-                              description: 'EnableServiceLinks indicates whether information about services should be injected into pod''s environment variables, matching the syntax of Docker links. Optional: Defaults to true.'
                               type: boolean
                             ephemeralContainers:
-                              description: List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.
                               items:
-                                description: An EphemeralContainer is a container that may be added temporarily to an existing pod for user-initiated activities such as debugging. Ephemeral containers have no resource or scheduling guarantees, and they will not be restarted when they exit or when a pod is removed or restarted. If an ephemeral container causes a pod to exceed its resource allocation, the pod may be evicted. Ephemeral containers may not be added by directly updating the pod spec. They must be added via the pod's ephemeralcontainers subresource, and they will appear in the pod spec once added. This is an alpha feature enabled by the EphemeralContainers feature flag.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -1277,72 +972,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Lifecycle is not allowed for ephemeral containers.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1350,64 +1024,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -1415,31 +1074,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -1447,37 +1100,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1485,114 +1128,86 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the ephemeral container specified as a DNS_LABEL. This name must be unique among all containers, init containers and ephemeral containers.
                                     type: string
                                   ports:
-                                    description: Ports are not allowed for ephemeral containers.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
                                       type: object
                                     type: array
                                   readinessProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1600,54 +1215,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: Resources are not allowed for ephemeral containers. Ephemeral containers use spare resources already allocated to the pod.
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -1656,7 +1260,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -1665,113 +1268,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: SecurityContext is not allowed for ephemeral containers.
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: Probes are not allowed for ephemeral containers.
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -1779,80 +1349,60 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   targetContainerName:
-                                    description: If set, the name of the container from PodSpec that this ephemeral container targets. The ephemeral container will be run in the namespaces (IPC, PID, etc) of this container. If not set then the ephemeral container is run in whatever namespaces are shared for the pod. Note that the container runtime must support this feature.
                                     type: string
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -1860,27 +1410,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -1888,135 +1430,99 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             hostAliases:
-                              description: HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.
                               items:
-                                description: HostAlias holds the mapping between IP and hostnames that will be injected as an entry in the pod's hosts file.
                                 properties:
                                   hostnames:
-                                    description: Hostnames for the above IP address.
                                     items:
                                       type: string
                                     type: array
                                   ip:
-                                    description: IP address of the host file entry.
                                     type: string
                                 type: object
                               type: array
                             hostIPC:
-                              description: 'Use the host''s ipc namespace. Optional: Default to false.'
                               type: boolean
                             hostNetwork:
-                              description: Host networking requested for this pod. Use the host's network namespace. If this option is set, the ports that will be used must be specified. Default to false.
                               type: boolean
                             hostPID:
-                              description: 'Use the host''s pid namespace. Optional: Default to false.'
                               type: boolean
                             hostname:
-                              description: Specifies the hostname of the Pod If not specified, the pod's hostname will be set to a system-defined value.
                               type: string
                             imagePullSecrets:
-                              description: 'ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod'
                               items:
-                                description: LocalObjectReference contains enough information to let you locate the referenced object inside the same namespace.
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                     type: string
                                 type: object
                               type: array
                             initContainers:
-                              description: 'List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
                               items:
-                                description: A single application container that you want to run within a pod.
                                 properties:
                                   args:
-                                    description: 'Arguments to the entrypoint. The docker image''s CMD is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   command:
-                                    description: 'Entrypoint array. Not executed within a shell. The docker image''s ENTRYPOINT is used if this is not provided. Variable references $(VAR_NAME) are expanded using the container''s environment. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
                                     items:
                                       type: string
                                     type: array
                                   env:
-                                    description: List of environment variables to set in the container. Cannot be updated.
                                     items:
-                                      description: EnvVar represents an environment variable present in a Container.
                                       properties:
                                         name:
-                                          description: Name of the environment variable. Must be a C_IDENTIFIER.
                                           type: string
                                         value:
-                                          description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
                                           type: string
                                         valueFrom:
-                                          description: Source for the environment variable's value. Cannot be used if value is not empty.
                                           properties:
                                             configMapKeyRef:
-                                              description: Selects a key of a ConfigMap.
                                               properties:
                                                 key:
-                                                  description: The key to select.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
                                               type: object
                                             fieldRef:
-                                              description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, metadata.labels, metadata.annotations, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
                                               type: object
                                             secretKeyRef:
-                                              description: Selects a key of a secret in the pod's namespace
                                               properties:
                                                 key:
-                                                  description: The key of the secret to select from.  Must be a valid secret key.
                                                   type: string
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               required:
                                               - key
@@ -2027,72 +1533,51 @@ spec:
                                       type: object
                                     type: array
                                   envFrom:
-                                    description: List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.
                                     items:
-                                      description: EnvFromSource represents the source of a set of ConfigMaps
                                       properties:
                                         configMapRef:
-                                          description: The ConfigMap to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the ConfigMap must be defined
                                               type: boolean
                                           type: object
                                         prefix:
-                                          description: An optional identifier to prepend to each key in the ConfigMap. Must be a C_IDENTIFIER.
                                           type: string
                                         secretRef:
-                                          description: The Secret to select from
                                           properties:
                                             name:
-                                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                               type: string
                                             optional:
-                                              description: Specify whether the Secret must be defined
                                               type: boolean
                                           type: object
                                       type: object
                                     type: array
                                   image:
-                                    description: 'Docker image name. More info: https://kubernetes.io/docs/concepts/containers/images This field is optional to allow higher level config management to default or override container images in workload controllers like Deployments and StatefulSets.'
                                     type: string
                                   imagePullPolicy:
-                                    description: 'Image pull policy. One of Always, Never, IfNotPresent. Defaults to Always if :latest tag is specified, or IfNotPresent otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
                                     type: string
                                   lifecycle:
-                                    description: Actions that the management system should take in response to container lifecycle events. Cannot be updated.
                                     properties:
                                       postStart:
-                                        description: 'PostStart is called immediately after a container is created. If the handler fails, the container is terminated and restarted according to its restart policy. Other management of the container blocks until the hook completes. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2100,64 +1585,49 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
                                             type: object
                                         type: object
                                       preStop:
-                                        description: 'PreStop is called immediately before a container is terminated due to an API request or management event such as liveness/startup probe failure, preemption, resource contention, etc. The handler is not called if the container crashes or exits. The reason for termination is passed to the handler. The Pod''s termination grace period countdown begins before the PreStop hooked is executed. Regardless of the outcome of the handler, the container will eventually terminate within the Pod''s termination grace period. Other management of the container blocks until the hook completes or until the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
                                         properties:
                                           exec:
-                                            description: One and only one of the following should be specified. Exec specifies the action to take.
                                             properties:
                                               command:
-                                                description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                                 items:
                                                   type: string
                                                 type: array
                                             type: object
                                           httpGet:
-                                            description: HTTPGet specifies the http request to perform.
                                             properties:
                                               host:
-                                                description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                                 type: string
                                               httpHeaders:
-                                                description: Custom headers to set in the request. HTTP allows repeated headers.
                                                 items:
-                                                  description: HTTPHeader describes a custom header to be used in HTTP probes
                                                   properties:
                                                     name:
-                                                      description: The header field name
                                                       type: string
                                                     value:
-                                                      description: The header field value
                                                       type: string
                                                   required:
                                                   - name
@@ -2165,31 +1635,25 @@ spec:
                                                   type: object
                                                 type: array
                                               path:
-                                                description: Path to access on the HTTP server.
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                               scheme:
-                                                description: Scheme to use for connecting to the host. Defaults to HTTP.
                                                 type: string
                                             required:
                                             - port
                                             type: object
                                           tcpSocket:
-                                            description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                             properties:
                                               host:
-                                                description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                                 type: string
                                               port:
                                                 anyOf:
                                                 - type: integer
                                                 - type: string
-                                                description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                                 x-kubernetes-int-or-string: true
                                             required:
                                             - port
@@ -2197,37 +1661,27 @@ spec:
                                         type: object
                                     type: object
                                   livenessProbe:
-                                    description: 'Periodic probe of container liveness. Container will be restarted if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2235,77 +1689,59 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   name:
-                                    description: Name of the container specified as a DNS_LABEL. Each container in a pod must have a unique name (DNS_LABEL). Cannot be updated.
                                     type: string
                                   ports:
-                                    description: List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default "0.0.0.0" address inside a container will be accessible from the network. Cannot be updated.
                                     items:
-                                      description: ContainerPort represents a network port in a single container.
                                       properties:
                                         containerPort:
-                                          description: Number of port to expose on the pod's IP address. This must be a valid port number, 0 < x < 65536.
                                           format: int32
                                           type: integer
                                         hostIP:
-                                          description: What host IP to bind the external port to.
                                           type: string
                                         hostPort:
-                                          description: Number of port to expose on the host. If specified, this must be a valid port number, 0 < x < 65536. If HostNetwork is specified, this must match ContainerPort. Most containers do not need this.
                                           format: int32
                                           type: integer
                                         name:
-                                          description: If specified, this must be an IANA_SVC_NAME and unique within the pod. Each named port in a pod must have a unique name. Name for the port that can be referred to by services.
                                           type: string
                                         protocol:
                                           default: TCP
-                                          description: Protocol for port. Must be UDP, TCP, or SCTP. Defaults to "TCP".
                                           type: string
                                       required:
                                       - containerPort
@@ -2316,37 +1752,27 @@ spec:
                                     - protocol
                                     x-kubernetes-list-type: map
                                   readinessProbe:
-                                    description: 'Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2354,54 +1780,43 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   resources:
-                                    description: 'Compute Resources required by this container. Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -2410,7 +1825,6 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -2419,113 +1833,80 @@ spec:
                                           - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                                         type: object
                                     type: object
                                   securityContext:
-                                    description: 'Security options the pod should run with. More info: https://kubernetes.io/docs/concepts/policy/security-context/ More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
                                     properties:
                                       allowPrivilegeEscalation:
-                                        description: 'AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
                                         type: boolean
                                       capabilities:
-                                        description: The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime.
                                         properties:
                                           add:
-                                            description: Added capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                           drop:
-                                            description: Removed capabilities
                                             items:
-                                              description: Capability represent POSIX capabilities type
                                               type: string
                                             type: array
                                         type: object
                                       privileged:
-                                        description: Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.
                                         type: boolean
                                       procMount:
-                                        description: procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.
                                         type: string
                                       readOnlyRootFilesystem:
-                                        description: Whether this container has a read-only root filesystem. Default is false.
                                         type: boolean
                                       runAsGroup:
-                                        description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       runAsNonRoot:
-                                        description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         type: boolean
                                       runAsUser:
-                                        description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         format: int64
                                         type: integer
                                       seLinuxOptions:
-                                        description: The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           level:
-                                            description: Level is SELinux level label that applies to the container.
                                             type: string
                                           role:
-                                            description: Role is a SELinux role label that applies to the container.
                                             type: string
                                           type:
-                                            description: Type is a SELinux type label that applies to the container.
                                             type: string
                                           user:
-                                            description: User is a SELinux user label that applies to the container.
                                             type: string
                                         type: object
                                       windowsOptions:
-                                        description: The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                         properties:
                                           gmsaCredentialSpec:
-                                            description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                             type: string
                                           gmsaCredentialSpecName:
-                                            description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                             type: string
                                           runAsUserName:
-                                            description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                             type: string
                                         type: object
                                     type: object
                                   startupProbe:
-                                    description: 'StartupProbe indicates that the Pod has successfully initialized. If specified, no other probes are executed until this completes successfully. If this probe fails, the Pod will be restarted, just as if the livenessProbe failed. This can be used to provide different probe parameters at the beginning of a Pod''s lifecycle, when it might take a long time to load data or warm a cache, than during steady-state operation. This cannot be updated. This is a beta feature enabled by the StartupProbe feature flag. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                     properties:
                                       exec:
-                                        description: One and only one of the following should be specified. Exec specifies the action to take.
                                         properties:
                                           command:
-                                            description: Command is the command line to execute inside the container, the working directory for the command  is root ('/') in the container's filesystem. The command is simply exec'd, it is not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use a shell, you need to explicitly call out to that shell. Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                             items:
                                               type: string
                                             type: array
                                         type: object
                                       failureThreshold:
-                                        description: Minimum consecutive failures for the probe to be considered failed after having succeeded. Defaults to 3. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       httpGet:
-                                        description: HTTPGet specifies the http request to perform.
                                         properties:
                                           host:
-                                            description: Host name to connect to, defaults to the pod IP. You probably want to set "Host" in httpHeaders instead.
                                             type: string
                                           httpHeaders:
-                                            description: Custom headers to set in the request. HTTP allows repeated headers.
                                             items:
-                                              description: HTTPHeader describes a custom header to be used in HTTP probes
                                               properties:
                                                 name:
-                                                  description: The header field name
                                                   type: string
                                                 value:
-                                                  description: The header field value
                                                   type: string
                                               required:
                                               - name
@@ -2533,77 +1914,58 @@ spec:
                                               type: object
                                             type: array
                                           path:
-                                            description: Path to access on the HTTP server.
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Name or number of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                           scheme:
-                                            description: Scheme to use for connecting to the host. Defaults to HTTP.
                                             type: string
                                         required:
                                         - port
                                         type: object
                                       initialDelaySeconds:
-                                        description: 'Number of seconds after the container has started before liveness probes are initiated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                       periodSeconds:
-                                        description: How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       successThreshold:
-                                        description: Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                                         format: int32
                                         type: integer
                                       tcpSocket:
-                                        description: 'TCPSocket specifies an action involving a TCP port. TCP hooks not yet supported TODO: implement a realistic TCP lifecycle hook'
                                         properties:
                                           host:
-                                            description: 'Optional: Host name to connect to, defaults to the pod IP.'
                                             type: string
                                           port:
                                             anyOf:
                                             - type: integer
                                             - type: string
-                                            description: Number or name of the port to access on the container. Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
                                             x-kubernetes-int-or-string: true
                                         required:
                                         - port
                                         type: object
                                       timeoutSeconds:
-                                        description: 'Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
                                         format: int32
                                         type: integer
                                     type: object
                                   stdin:
-                                    description: Whether this container should allocate a buffer for stdin in the container runtime. If this is not set, reads from stdin in the container will always result in EOF. Default is false.
                                     type: boolean
                                   stdinOnce:
-                                    description: Whether the container runtime should close the stdin channel after it has been opened by a single attach. When stdin is true the stdin stream will remain open across multiple attach sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the first client attaches to stdin, and then remains open and accepts data until the client disconnects, at which time stdin is closed and remains closed until the container is restarted. If this flag is false, a container processes that reads from stdin will never receive an EOF. Default is false
                                     type: boolean
                                   terminationMessagePath:
-                                    description: 'Optional: Path at which the file to which the container''s termination message will be written is mounted into the container''s filesystem. Message written is intended to be brief final status, such as an assertion failure message. Will be truncated by the node if greater than 4096 bytes. The total message length across all containers will be limited to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
                                     type: string
                                   terminationMessagePolicy:
-                                    description: Indicate how the termination message should be populated. File will use the contents of terminationMessagePath to populate the container status message on both success and failure. FallbackToLogsOnError will use the last chunk of container log output if the termination message file is empty and the container exited with an error. The log output is limited to 2048 bytes or 80 lines, whichever is smaller. Defaults to File. Cannot be updated.
                                     type: string
                                   tty:
-                                    description: Whether this container should allocate a TTY for itself, also requires 'stdin' to be true. Default is false.
                                     type: boolean
                                   volumeDevices:
-                                    description: volumeDevices is the list of block devices to be used by the container.
                                     items:
-                                      description: volumeDevice describes a mapping of a raw block device within a container.
                                       properties:
                                         devicePath:
-                                          description: devicePath is the path inside of the container that the device will be mapped to.
                                           type: string
                                         name:
-                                          description: name must match the name of a persistentVolumeClaim in the pod
                                           type: string
                                       required:
                                       - devicePath
@@ -2611,27 +1973,19 @@ spec:
                                       type: object
                                     type: array
                                   volumeMounts:
-                                    description: Pod volumes to mount into the container's filesystem. Cannot be updated.
                                     items:
-                                      description: VolumeMount describes a mounting of a Volume within a container.
                                       properties:
                                         mountPath:
-                                          description: Path within the container at which the volume should be mounted.  Must not contain ':'.
                                           type: string
                                         mountPropagation:
-                                          description: mountPropagation determines how mounts are propagated from the host to container and the other way around. When not set, MountPropagationNone is used. This field is beta in 1.10.
                                           type: string
                                         name:
-                                          description: This must match the Name of a Volume.
                                           type: string
                                         readOnly:
-                                          description: Mounted read-only if true, read-write otherwise (false or unspecified). Defaults to false.
                                           type: boolean
                                         subPath:
-                                          description: Path within the volume from which the container's volume should be mounted. Defaults to "" (volume's root).
                                           type: string
                                         subPathExpr:
-                                          description: Expanded path within the volume from which the container's volume should be mounted. Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment. Defaults to "" (volume's root). SubPathExpr and SubPath are mutually exclusive.
                                           type: string
                                       required:
                                       - mountPath
@@ -2639,19 +1993,16 @@ spec:
                                       type: object
                                     type: array
                                   workingDir:
-                                    description: Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.
                                     type: string
                                 required:
                                 - name
                                 type: object
                               type: array
                             nodeName:
-                              description: NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.
                               type: string
                             nodeSelector:
                               additionalProperties:
                                 type: string
-                              description: 'NodeSelector is a selector which must be true for the pod to fit on a node. Selector which must match a node''s labels for the pod to be scheduled on that node. More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
                               type: object
                             overhead:
                               additionalProperties:
@@ -2660,92 +2011,66 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.'
                               type: object
                             preemptionPolicy:
-                              description: PreemptionPolicy is the Policy for preempting pods with lower priority. One of Never, PreemptLowerPriority. Defaults to PreemptLowerPriority if unset. This field is alpha-level and is only honored by servers that enable the NonPreemptingPriority feature.
                               type: string
                             priority:
-                              description: The priority value. Various system components use this field to find the priority of the pod. When Priority Admission Controller is enabled, it prevents users from setting this field. The admission controller populates this field from PriorityClassName. The higher the value, the higher the priority.
                               format: int32
                               type: integer
                             priorityClassName:
-                              description: If specified, indicates the pod's priority. "system-node-critical" and "system-cluster-critical" are two special keywords which indicate the highest priorities with the former being the highest priority. Any other name must be defined by creating a PriorityClass object with that name. If not specified, the pod priority will be default or zero if there is no default.
                               type: string
                             readinessGates:
-                              description: 'If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to "True" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md'
                               items:
-                                description: PodReadinessGate contains the reference to a pod condition
                                 properties:
                                   conditionType:
-                                    description: ConditionType refers to a condition in the pod's condition list with matching type.
                                     type: string
                                 required:
                                 - conditionType
                                 type: object
                               type: array
                             restartPolicy:
-                              description: 'Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy'
                               type: string
                             runtimeClassName:
-                              description: 'RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the "legacy" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.'
                               type: string
                             schedulerName:
-                              description: If specified, the pod will be dispatched by specified scheduler. If not specified, the pod will be dispatched by default scheduler.
                               type: string
                             securityContext:
-                              description: 'SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.'
                               properties:
                                 fsGroup:
-                                  description: "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod: \n 1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw---- \n If unset, the Kubelet will not modify the ownership and permissions of any volume."
                                   format: int64
                                   type: integer
                                 fsGroupChangePolicy:
-                                  description: 'fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are "OnRootMismatch" and "Always". If not specified defaults to "Always".'
                                   type: string
                                 runAsGroup:
-                                  description: The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 runAsNonRoot:
-                                  description: Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   type: boolean
                                 runAsUser:
-                                  description: The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   format: int64
                                   type: integer
                                 seLinuxOptions:
-                                  description: The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.
                                   properties:
                                     level:
-                                      description: Level is SELinux level label that applies to the container.
                                       type: string
                                     role:
-                                      description: Role is a SELinux role label that applies to the container.
                                       type: string
                                     type:
-                                      description: Type is a SELinux type label that applies to the container.
                                       type: string
                                     user:
-                                      description: User is a SELinux user label that applies to the container.
                                       type: string
                                   type: object
                                 supplementalGroups:
-                                  description: A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.
                                   items:
                                     format: int64
                                     type: integer
                                   type: array
                                 sysctls:
-                                  description: Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.
                                   items:
-                                    description: Sysctl defines a kernel parameter to be set
                                     properties:
                                       name:
-                                        description: Name of a property to set
                                         type: string
                                       value:
-                                        description: Value of a property to set
                                         type: string
                                     required:
                                     - name
@@ -2753,79 +2078,55 @@ spec:
                                     type: object
                                   type: array
                                 windowsOptions:
-                                  description: The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                   properties:
                                     gmsaCredentialSpec:
-                                      description: GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.
                                       type: string
                                     gmsaCredentialSpecName:
-                                      description: GMSACredentialSpecName is the name of the GMSA credential spec to use.
                                       type: string
                                     runAsUserName:
-                                      description: The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
                                       type: string
                                   type: object
                               type: object
                             serviceAccount:
-                              description: 'DeprecatedServiceAccount is a depreciated alias for ServiceAccountName. Deprecated: Use serviceAccountName instead.'
                               type: string
                             serviceAccountName:
-                              description: 'ServiceAccountName is the name of the ServiceAccount to use to run this pod. More info: https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/'
                               type: string
                             shareProcessNamespace:
-                              description: 'Share a single process namespace between all of the containers in a pod. When this is set containers will be able to view and signal processes from other containers in the same pod, and the first process in each container will not be assigned PID 1. HostPID and ShareProcessNamespace cannot both be set. Optional: Default to false.'
                               type: boolean
                             subdomain:
-                              description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod namespace>.svc.<cluster domain>". If not specified, the pod will not have a domainname at all.
                               type: string
                             terminationGracePeriodSeconds:
-                              description: Optional duration in seconds the pod needs to terminate gracefully. May be decreased in delete request. Value must be non-negative integer. The value zero indicates delete immediately. If this value is nil, the default grace period will be used instead. The grace period is the duration in seconds after the processes running in the pod are sent a termination signal and the time when the processes are forcibly halted with a kill signal. Set this value longer than the expected cleanup time for your process. Defaults to 30 seconds.
                               format: int64
                               type: integer
                             tolerations:
-                              description: If specified, the pod's tolerations.
                               items:
-                                description: The pod this Toleration is attached to tolerates any taint that matches the triple <key,value,effect> using the matching operator <operator>.
                                 properties:
                                   effect:
-                                    description: Effect indicates the taint effect to match. Empty means match all taint effects. When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                     type: string
                                   key:
-                                    description: Key is the taint key that the toleration applies to. Empty means match all taint keys. If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                     type: string
                                   operator:
-                                    description: Operator represents a key's relationship to the value. Valid operators are Exists and Equal. Defaults to Equal. Exists is equivalent to wildcard for value, so that a pod can tolerate all taints of a particular category.
                                     type: string
                                   tolerationSeconds:
-                                    description: TolerationSeconds represents the period of time the toleration (which must be of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default, it is not set, which means tolerate the taint forever (do not evict). Zero and negative values will be treated as 0 (evict immediately) by the system.
                                     format: int64
                                     type: integer
                                   value:
-                                    description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                     type: string
                                 type: object
                               type: array
                             topologySpreadConstraints:
-                              description: TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. This field is only honored by clusters that enable the EvenPodsSpread feature. All topologySpreadConstraints are ANDed.
                               items:
-                                description: TopologySpreadConstraint specifies how to spread matching pods among the given topology.
                                 properties:
                                   labelSelector:
-                                    description: LabelSelector is used to find matching pods. Pods that match this label selector are counted to determine the number of pods in their corresponding topology domain.
                                     properties:
                                       matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
                                         items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
                                           properties:
                                             key:
-                                              description: key is the label key that the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -2837,18 +2138,14 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                   maxSkew:
-                                    description: 'MaxSkew describes the degree to which pods may be unevenly distributed. It''s the maximum permitted difference between the number of matching pods in any two topology domains of a given topology type. For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 1/1/0: | zone1 | zone2 | zone3 | |   P   |   P   |       | - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 1/1/1; scheduling it onto zone1(zone2) would make the ActualSkew(2-0) on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming pod can be scheduled onto any zone. It''s a required field. Default value is 1 and 0 is not allowed.'
                                     format: int32
                                     type: integer
                                   topologyKey:
-                                    description: TopologyKey is the key of node labels. Nodes that have a label with this key and identical values are considered to be in the same topology. We consider each <key, value> as a "bucket", and try to put balanced number of pods into each bucket. It's a required field.
                                     type: string
                                   whenUnsatisfiable:
-                                    description: 'WhenUnsatisfiable indicates how to deal with a pod if it doesn''t satisfy the spread constraint. - DoNotSchedule (default) tells the scheduler not to schedule it - ScheduleAnyway tells the scheduler to still schedule it It''s considered as "Unsatisfiable" if and only if placing incoming pod on any topology violates "MaxSkew". For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same labelSelector spread as 3/1/1: | zone1 | zone2 | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler won''t make it *more* imbalanced. It''s a required field.'
                                     type: string
                                 required:
                                 - maxSkew
@@ -2861,143 +2158,104 @@ spec:
                               - whenUnsatisfiable
                               x-kubernetes-list-type: map
                             volumes:
-                              description: 'List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes'
                               items:
-                                description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                                 properties:
                                   awsElasticBlockStore:
-                                    description: 'AWSElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Specify "true" to force and set the ReadOnly property in VolumeMounts to "true". If omitted, the default is "false". More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: boolean
                                       volumeID:
-                                        description: 'Unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   azureDisk:
-                                    description: AzureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
                                     properties:
                                       cachingMode:
-                                        description: 'Host Caching mode: None, Read Only, Read Write.'
                                         type: string
                                       diskName:
-                                        description: The Name of the data disk in the blob storage
                                         type: string
                                       diskURI:
-                                        description: The URI the data disk in the blob storage
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       kind:
-                                        description: 'Expected values Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                     required:
                                     - diskName
                                     - diskURI
                                     type: object
                                   azureFile:
-                                    description: AzureFile represents an Azure File Service mount on the host and bind mount to the pod.
                                     properties:
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretName:
-                                        description: the name of secret that contains Azure Storage Account Name and Key
                                         type: string
                                       shareName:
-                                        description: Share Name
                                         type: string
                                     required:
                                     - secretName
                                     - shareName
                                     type: object
                                   cephfs:
-                                    description: CephFS represents a Ceph FS mount on the host that shares a pod's lifetime
                                     properties:
                                       monitors:
-                                        description: 'Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       path:
-                                        description: 'Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: boolean
                                       secretFile:
-                                        description: 'Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'Optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - monitors
                                     type: object
                                   cinder:
-                                    description: 'Cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: points to a secret object containing parameters used to connect to OpenStack.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeID:
-                                        description: 'volume id used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   configMap:
-                                    description: ConfigMap represents a configMap that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3005,85 +2263,63 @@ spec:
                                           type: object
                                         type: array
                                       name:
-                                        description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                         type: string
                                       optional:
-                                        description: Specify whether the ConfigMap or its keys must be defined
                                         type: boolean
                                     type: object
                                   csi:
-                                    description: CSI (Container Storage Interface) represents storage that is handled by an external CSI driver (Alpha feature).
                                     properties:
                                       driver:
-                                        description: Driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
                                         type: string
                                       nodePublishSecretRef:
-                                        description: NodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       readOnly:
-                                        description: Specifies a read-only configuration for the volume. Defaults to false (read/write).
                                         type: boolean
                                       volumeAttributes:
                                         additionalProperties:
                                           type: string
-                                        description: VolumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   downwardAPI:
-                                    description: DownwardAPI represents downward API about the pod that should populate this volume
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: Items is a list of downward API volume file
                                         items:
-                                          description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                           properties:
                                             fieldRef:
-                                              description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                               properties:
                                                 apiVersion:
-                                                  description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                   type: string
                                                 fieldPath:
-                                                  description: Path of the field to select in the specified API version.
                                                   type: string
                                               required:
                                               - fieldPath
                                               type: object
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                               type: string
                                             resourceFieldRef:
-                                              description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                               properties:
                                                 containerName:
-                                                  description: 'Container name: required for volumes, optional for env vars'
                                                   type: string
                                                 divisor:
                                                   anyOf:
                                                   - type: integer
                                                   - type: string
-                                                  description: Specifies the output format of the exposed resources, defaults to "1"
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
                                                 resource:
-                                                  description: 'Required: resource to select'
                                                   type: string
                                               required:
                                               - resource
@@ -3094,184 +2330,136 @@ spec:
                                         type: array
                                     type: object
                                   emptyDir:
-                                    description: 'EmptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                     properties:
                                       medium:
-                                        description: 'What type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
                                         type: string
                                       sizeLimit:
                                         anyOf:
                                         - type: integer
                                         - type: string
-                                        description: 'Total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
                                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                         x-kubernetes-int-or-string: true
                                     type: object
                                   fc:
-                                    description: FC represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       lun:
-                                        description: 'Optional: FC target lun number'
                                         format: int32
                                         type: integer
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       targetWWNs:
-                                        description: 'Optional: FC target worldwide names (WWNs)'
                                         items:
                                           type: string
                                         type: array
                                       wwids:
-                                        description: 'Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
                                         items:
                                           type: string
                                         type: array
                                     type: object
                                   flexVolume:
-                                    description: FlexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
                                     properties:
                                       driver:
-                                        description: Driver is the name of the driver to use for this volume.
                                         type: string
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                         type: string
                                       options:
                                         additionalProperties:
                                           type: string
-                                        description: 'Optional: Extra command options if any.'
                                         type: object
                                       readOnly:
-                                        description: 'Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
                                         type: boolean
                                       secretRef:
-                                        description: 'Optional: SecretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                     required:
                                     - driver
                                     type: object
                                   flocker:
-                                    description: Flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
                                     properties:
                                       datasetName:
-                                        description: Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
                                         type: string
                                       datasetUUID:
-                                        description: UUID of the dataset. This is unique identifier of a Flocker dataset
                                         type: string
                                     type: object
                                   gcePersistentDisk:
-                                    description: 'GCEPersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       partition:
-                                        description: 'The partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         format: int32
                                         type: integer
                                       pdName:
-                                        description: 'Unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
                                         type: boolean
                                     required:
                                     - pdName
                                     type: object
                                   gitRepo:
-                                    description: 'GitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
                                     properties:
                                       directory:
-                                        description: Target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
                                         type: string
                                       repository:
-                                        description: Repository URL
                                         type: string
                                       revision:
-                                        description: Commit hash for the specified revision.
                                         type: string
                                     required:
                                     - repository
                                     type: object
                                   glusterfs:
-                                    description: 'Glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
                                     properties:
                                       endpoints:
-                                        description: 'EndpointsName is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       path:
-                                        description: 'Path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
                                         type: boolean
                                     required:
                                     - endpoints
                                     - path
                                     type: object
                                   hostPath:
-                                    description: 'HostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath --- TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not mount host directories as read/write.'
                                     properties:
                                       path:
-                                        description: 'Path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                       type:
-                                        description: 'Type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
                                         type: string
                                     required:
                                     - path
                                     type: object
                                   iscsi:
-                                    description: 'ISCSI represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
                                     properties:
                                       chapAuthDiscovery:
-                                        description: whether support iSCSI Discovery CHAP authentication
                                         type: boolean
                                       chapAuthSession:
-                                        description: whether support iSCSI Session CHAP authentication
                                         type: boolean
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       initiatorName:
-                                        description: Custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
                                         type: string
                                       iqn:
-                                        description: Target iSCSI Qualified Name.
                                         type: string
                                       iscsiInterface:
-                                        description: iSCSI Interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
                                         type: string
                                       lun:
-                                        description: iSCSI Target Lun number.
                                         format: int32
                                         type: integer
                                       portals:
-                                        description: iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         items:
                                           type: string
                                         type: array
                                       readOnly:
-                                        description: ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
                                         type: boolean
                                       secretRef:
-                                        description: CHAP Secret for iSCSI target and initiator authentication
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       targetPortal:
-                                        description: iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
                                         type: string
                                     required:
                                     - iqn
@@ -3279,92 +2467,67 @@ spec:
                                     - targetPortal
                                     type: object
                                   name:
-                                    description: 'Volume''s name. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                     type: string
                                   nfs:
-                                    description: 'NFS represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                     properties:
                                       path:
-                                        description: 'Path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: boolean
                                       server:
-                                        description: 'Server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
                                         type: string
                                     required:
                                     - path
                                     - server
                                     type: object
                                   persistentVolumeClaim:
-                                    description: 'PersistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                     properties:
                                       claimName:
-                                        description: 'ClaimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
                                         type: string
                                       readOnly:
-                                        description: Will force the ReadOnly setting in VolumeMounts. Default false.
                                         type: boolean
                                     required:
                                     - claimName
                                     type: object
                                   photonPersistentDisk:
-                                    description: PhotonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       pdID:
-                                        description: ID that identifies Photon Controller persistent disk
                                         type: string
                                     required:
                                     - pdID
                                     type: object
                                   portworxVolume:
-                                    description: PortworxVolume represents a portworx volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: FSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       volumeID:
-                                        description: VolumeID uniquely identifies a Portworx volume
                                         type: string
                                     required:
                                     - volumeID
                                     type: object
                                   projected:
-                                    description: Items for all in one resources secrets, configmaps, and downward API
                                     properties:
                                       defaultMode:
-                                        description: Mode bits to use on created files by default. Must be a value between 0 and 0777. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
                                         format: int32
                                         type: integer
                                       sources:
-                                        description: list of volume projections
                                         items:
-                                          description: Projection that may be projected along with other supported volume types
                                           properties:
                                             configMap:
-                                              description: information about the configMap data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3372,54 +2535,40 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the ConfigMap or its keys must be defined
                                                   type: boolean
                                               type: object
                                             downwardAPI:
-                                              description: information about the downwardAPI data to project
                                               properties:
                                                 items:
-                                                  description: Items is a list of DownwardAPIVolume file
                                                   items:
-                                                    description: DownwardAPIVolumeFile represents information to create the file containing the pod field
                                                     properties:
                                                       fieldRef:
-                                                        description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
                                                         properties:
                                                           apiVersion:
-                                                            description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
                                                             type: string
                                                           fieldPath:
-                                                            description: Path of the field to select in the specified API version.
                                                             type: string
                                                         required:
                                                         - fieldPath
                                                         type: object
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
                                                         type: string
                                                       resourceFieldRef:
-                                                        description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
                                                         properties:
                                                           containerName:
-                                                            description: 'Container name: required for volumes, optional for env vars'
                                                             type: string
                                                           divisor:
                                                             anyOf:
                                                             - type: integer
                                                             - type: string
-                                                            description: Specifies the output format of the exposed resources, defaults to "1"
                                                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                             x-kubernetes-int-or-string: true
                                                           resource:
-                                                            description: 'Required: resource to select'
                                                             type: string
                                                         required:
                                                         - resource
@@ -3430,22 +2579,16 @@ spec:
                                                   type: array
                                               type: object
                                             secret:
-                                              description: information about the secret data to project
                                               properties:
                                                 items:
-                                                  description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                                   items:
-                                                    description: Maps a string key to a path within a volume.
                                                     properties:
                                                       key:
-                                                        description: The key to project.
                                                         type: string
                                                       mode:
-                                                        description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                                         format: int32
                                                         type: integer
                                                       path:
-                                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                                         type: string
                                                     required:
                                                     - key
@@ -3453,24 +2596,18 @@ spec:
                                                     type: object
                                                   type: array
                                                 name:
-                                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                                   type: string
                                                 optional:
-                                                  description: Specify whether the Secret or its key must be defined
                                                   type: boolean
                                               type: object
                                             serviceAccountToken:
-                                              description: information about the serviceAccountToken data to project
                                               properties:
                                                 audience:
-                                                  description: Audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
                                                   type: string
                                                 expirationSeconds:
-                                                  description: ExpirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
                                                   format: int64
                                                   type: integer
                                                 path:
-                                                  description: Path is the path relative to the mount point of the file to project the token into.
                                                   type: string
                                               required:
                                               - path
@@ -3481,103 +2618,74 @@ spec:
                                     - sources
                                     type: object
                                   quobyte:
-                                    description: Quobyte represents a Quobyte mount on the host that shares a pod's lifetime
                                     properties:
                                       group:
-                                        description: Group to map volume access to Default is no group
                                         type: string
                                       readOnly:
-                                        description: ReadOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
                                         type: boolean
                                       registry:
-                                        description: Registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
                                         type: string
                                       tenant:
-                                        description: Tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                         type: string
                                       user:
-                                        description: User to map volume access to Defaults to serivceaccount user
                                         type: string
                                       volume:
-                                        description: Volume is a string that references an already created Quobyte volume by name.
                                         type: string
                                     required:
                                     - registry
                                     - volume
                                     type: object
                                   rbd:
-                                    description: 'RBD represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
                                     properties:
                                       fsType:
-                                        description: 'Filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd TODO: how do we prevent errors in the filesystem from compromising the machine'
                                         type: string
                                       image:
-                                        description: 'The rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       keyring:
-                                        description: 'Keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       monitors:
-                                        description: 'A collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         items:
                                           type: string
                                         type: array
                                       pool:
-                                        description: 'The rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                       readOnly:
-                                        description: 'ReadOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: boolean
                                       secretRef:
-                                        description: 'SecretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       user:
-                                        description: 'The rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
                                         type: string
                                     required:
                                     - image
                                     - monitors
                                     type: object
                                   scaleIO:
-                                    description: ScaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
                                         type: string
                                       gateway:
-                                        description: The host address of the ScaleIO API Gateway.
                                         type: string
                                       protectionDomain:
-                                        description: The name of the ScaleIO Protection Domain for the configured storage.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       sslEnabled:
-                                        description: Flag to enable/disable SSL communication with Gateway, default false
                                         type: boolean
                                       storageMode:
-                                        description: Indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
                                         type: string
                                       storagePool:
-                                        description: The ScaleIO Storage Pool associated with the protection domain.
                                         type: string
                                       system:
-                                        description: The name of the storage system as configured in ScaleIO.
                                         type: string
                                       volumeName:
-                                        description: The name of a volume already created in the ScaleIO system that is associated with this volume source.
                                         type: string
                                     required:
                                     - gateway
@@ -3585,26 +2693,19 @@ spec:
                                     - system
                                     type: object
                                   secret:
-                                    description: 'Secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                     properties:
                                       defaultMode:
-                                        description: 'Optional: mode bits to use on created files by default. Must be a value between 0 and 0777. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                         format: int32
                                         type: integer
                                       items:
-                                        description: If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
                                         items:
-                                          description: Maps a string key to a path within a volume.
                                           properties:
                                             key:
-                                              description: The key to project.
                                               type: string
                                             mode:
-                                              description: 'Optional: mode bits to use on this file, must be a value between 0 and 0777. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
                                               format: int32
                                               type: integer
                                             path:
-                                              description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
                                               type: string
                                           required:
                                           - key
@@ -3612,49 +2713,35 @@ spec:
                                           type: object
                                         type: array
                                       optional:
-                                        description: Specify whether the Secret or its keys must be defined
                                         type: boolean
                                       secretName:
-                                        description: 'Name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
                                         type: string
                                     type: object
                                   storageos:
-                                    description: StorageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       readOnly:
-                                        description: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
                                         type: boolean
                                       secretRef:
-                                        description: SecretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
                                         properties:
                                           name:
-                                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
                                             type: string
                                         type: object
                                       volumeName:
-                                        description: VolumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
                                         type: string
                                       volumeNamespace:
-                                        description: VolumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
                                         type: string
                                     type: object
                                   vsphereVolume:
-                                    description: VsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
                                     properties:
                                       fsType:
-                                        description: Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                         type: string
                                       storagePolicyID:
-                                        description: Storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
                                         type: string
                                       storagePolicyName:
-                                        description: Storage Policy Based Management (SPBM) profile name.
                                         type: string
                                       volumePath:
-                                        description: Path that identifies vSphere volume vmdk
                                         type: string
                                     required:
                                     - volumePath
@@ -3668,42 +2755,31 @@ spec:
                           type: object
                       type: object
                   type: object
-                description: 'XGBoostReplicaSpecs is map of ReplicaType and ReplicaSpec specifies the XGBoost replicas to run. For example,   {     "PS": ReplicaSpec,     "Worker": ReplicaSpec,   }'
                 type: object
             required:
             - xgbReplicaSpecs
             type: object
           status:
-            description: XGBoostJobStatus defines the observed state of XGBoostJob
             properties:
               completionTime:
-                description: Represents time when the job was completed. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               conditions:
-                description: Conditions is an array of current observed job conditions.
                 items:
-                  description: JobCondition describes the state of the job at a certain point.
                   properties:
                     lastTransitionTime:
-                      description: Last time the condition transitioned from one status to another.
                       format: date-time
                       type: string
                     lastUpdateTime:
-                      description: The last time this condition was updated.
                       format: date-time
                       type: string
                     message:
-                      description: A human readable message indicating details about the transition.
                       type: string
                     reason:
-                      description: The reason for the condition's last transition.
                       type: string
                     status:
-                      description: Status of the condition, one of True, False, Unknown.
                       type: string
                     type:
-                      description: Type of job condition.
                       type: string
                   required:
                   - status
@@ -3711,34 +2787,26 @@ spec:
                   type: object
                 type: array
               lastReconcileTime:
-                description: Represents last time when the job was reconciled. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
               replicaStatuses:
                 additionalProperties:
-                  description: ReplicaStatus represents the current observed state of the replica.
                   properties:
                     active:
-                      description: The number of actively running pods.
                       format: int32
                       type: integer
                     evicted:
-                      description: The number of pods which reached phase Failed and reason is Evicted, it is included in the number of Failed.
                       format: int32
                       type: integer
                     failed:
-                      description: The number of pods which reached phase Failed.
                       format: int32
                       type: integer
                     succeeded:
-                      description: The number of pods which reached phase Succeeded.
                       format: int32
                       type: integer
                   type: object
-                description: ReplicaStatuses is map of ReplicaType and ReplicaStatus, specifies the status of each replica.
                 type: object
               startTime:
-                description: Represents time when the job was acknowledged by the job controller. It is not guaranteed to be set in happens-before order across separate operations. It is represented in RFC3339 form and is in UTC.
                 format: date-time
                 type: string
             required:

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -6,6 +6,9 @@ resources:
 - bases/kubeflow.org_pytorchjobs.yaml
 - bases/xdl.kubedl.io_xdljobs.yaml
 - bases/xgboostjob.kubeflow.org_xgboostjobs.yaml
+- bases/elasticdl.org_elasticdljobs.yaml
+- bases/kubedl.io_marsjobs.yaml
+- bases/kubeflow.org_mpijobs.yaml
 # +kubebuilder:scaffold:crdkustomizeresource
 
 patchesStrategicMerge:

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,12 +1,12 @@
 # Adds namespace to all resources.
-namespace: unified-operator-system
+namespace: kubedl-system
 
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
 # Note that it should also match with the prefix (text before '-') of the namespace
 # field above.
-namePrefix: unified-operator-
+namePrefix: kubedl-
 
 # Labels to add to all resources and selectors.
 #commonLabels:

--- a/config/manager/all_in_one.yaml
+++ b/config/manager/all_in_one.yaml
@@ -18,6 +18,8 @@ rules:
   - kubeflow.org
   resources:
   - tfjobs
+  - pytorchjobs
+  - mpijobs
   verbs:
   - get
   - list
@@ -30,30 +32,8 @@ rules:
   - kubeflow.org
   resources:
   - tfjobs/status
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - kubeflow.org
-  resources:
-  - pytorchjobs
-  verbs:
-  - get
-  - list
-  - watch
-  - create
-  - update
-  - patch
-  - delete
-- apiGroups:
-  - kubeflow.org
-  resources:
   - pytorchjobs/status
+  - mpijobs/status
   verbs:
   - get
   - list

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: kubedl/kubedl
+  newTag: v0.1.0


### PR DESCRIPTION
1. resolve errors when running Makefile, which caused by auto-generated field 'description' in CRD manifests files and rejected by apiserver, there comes a [workaround](https://github.com/kubernetes-sigs/kubebuilder/issues/1140) from `kubebuilder` community.

> kustomize build config/crd | kubectl apply -f -
customresourcedefinition.apiextensions.k8s.io/xdljobs.xdl.kubedl.io created
customresourcedefinition.apiextensions.k8s.io/xgboostjobs.xgboostjob.kubeflow.org created
Error from server (Invalid): error when creating "STDIN": CustomResourceDefinition.apiextensions.k8s.io "pytorchjobs.kubeflow.org" is invalid: spec.validation.openAPIV3Schema.properties[metadata]: Forbidden: must not specify anything other than name and generateName, but metadata is implicitly specified
Error from server (Invalid): error when creating "STDIN": CustomResourceDefinition.apiextensions.k8s.io "tfjobs.kubeflow.org" is invalid: spec.validation.openAPIV3Schema.properties[metadata]: Forbidden: must not specify anything other than name and generateName, but metadata is implicitly specified
make: *** [install] Error 1

2. revise some config files.